### PR TITLE
feat: 팀 목록 조회 API 개선

### DIFF
--- a/mashup-api/src/main/java/kr/mashup/branding/config/security/SecurityConfig.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/config/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.antMatcher("/**")
             .authorizeRequests()
             .antMatchers("/hello").permitAll()
-            .antMatchers("/api/v1/test/**").permitAll()
+            .antMatchers("/api/v1/teams/**").permitAll()
             .antMatchers("/api/v1/applicants/login").permitAll()
             .antMatchers("/api/v1/**").hasAuthority(APPLICANT_ROLE_NAME);
         http.csrf().disable();

--- a/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamAssembler.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamAssembler.java
@@ -9,9 +9,7 @@ public class TeamAssembler {
     public TeamResponse toTeamResponse(Team team) {
         return new TeamResponse(
             team.getTeamId(),
-            team.getName(),
-            team.getCreatedAt(),
-            team.getUpdatedAt()
+            team.getName()
         );
     }
 }

--- a/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamController.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.team.TeamFacadeService;
+import kr.mashup.branding.ui.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -20,9 +21,11 @@ public class TeamController {
 
     @ApiOperation("팀 목록 조회")
     @GetMapping
-    public List<TeamResponse> getTeams() {
-        return teamFacadeService.getTeams().stream()
-            .map(teamAssembler::toTeamResponse)
-            .collect(Collectors.toList());
+    public ApiResponse<List<TeamResponse>> getTeams() {
+        return ApiResponse.success(
+            teamFacadeService.getTeams().stream()
+                .map(teamAssembler::toTeamResponse)
+                .collect(Collectors.toList())
+        );
     }
 }

--- a/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamResponse.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/ui/team/TeamResponse.java
@@ -1,13 +1,11 @@
 package kr.mashup.branding.ui.team;
 
-import java.time.LocalDateTime;
-
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class TeamResponse {
-    private final Long teamId;
-    private final String name;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
+    private Long teamId;
+    private String name;
 }

--- a/mashup-api/src/test/java/kr/mashup/branding/ui/team/TeamControllerTest.java
+++ b/mashup-api/src/test/java/kr/mashup/branding/ui/team/TeamControllerTest.java
@@ -1,0 +1,63 @@
+package kr.mashup.branding.ui.team;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.mashup.branding.domain.team.CreateTeamVo;
+import kr.mashup.branding.domain.team.TeamService;
+import kr.mashup.branding.ui.ApiResponse;
+
+@AutoConfigureMockMvc
+@Transactional
+@SpringBootTest
+class TeamControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private TeamService teamService;
+
+    @DisplayName("로그인하지 않아도 팀 목록 조회 할 수 있음")
+    @Test
+    void getTeams() throws Exception {
+        // given
+        teamService.create(CreateTeamVo.of("Design"));
+        teamService.create(CreateTeamVo.of("Android"));
+        teamService.create(CreateTeamVo.of("iOS"));
+        teamService.create(CreateTeamVo.of("Web"));
+        teamService.create(CreateTeamVo.of("Node"));
+        teamService.create(CreateTeamVo.of("Spring"));
+        // when
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/teams"))
+            // then 1
+            .andExpect(status().isOk())
+            .andReturn();
+        ApiResponse<List<TeamResponse>> actual = objectMapper.readValue(
+            mvcResult.getResponse().getContentAsByteArray(),
+            new TypeReference<ApiResponse<List<TeamResponse>>>() {
+            }
+        );
+        // then2
+        assertThat(actual.getData()).hasSize(6);
+        Set<String> teamNames = actual.getData().stream().map(it -> it.getName()).collect(Collectors.toSet());
+        assertThat(teamNames).contains("Design", "Android", "iOS", "Web", "Node", "Spring");
+    }
+}


### PR DESCRIPTION
- 로그인하지 않아도 팀목록조회 API 호출가능하게 변경
- 공통 응답 dto 적용
- 사용하지 않는 필드 제거 (createdAt, updatedAt)
- 테스트 추가