### PR TITLE
feat: local, dev 환경에서는 지원서가  있어도 설문지 삭제 가능

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/ProfileFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/ProfileFacadeService.java
@@ -1,0 +1,30 @@
+package kr.mashup.branding.facade;
+
+import java.util.Arrays;
+
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ProfileFacadeService {
+    private final static String LOCAL = "local";
+    private final static String DEVELOP = "develop";
+    private final static String PRODUCTION = "production";
+
+    private final Environment environment;
+
+    public boolean isLocal() {
+        return Arrays.asList(environment.getActiveProfiles()).contains(LOCAL);
+    }
+
+    public boolean isDevelop() {
+        return Arrays.asList(environment.getActiveProfiles()).contains(DEVELOP);
+    }
+
+    public boolean isProduction() {
+        return Arrays.asList(environment.getActiveProfiles()).contains(PRODUCTION);
+    }
+}

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormDeleteFailedException.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormDeleteFailedException.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.facade.application.form;
+
+import kr.mashup.branding.domain.ResultCode;
+import kr.mashup.branding.domain.exception.BadRequestException;
+
+public class ApplicationFormDeleteFailedException extends BadRequestException {
+    public ApplicationFormDeleteFailedException() {
+        super(ResultCode.APPLICATION_FORM_DELETE_NOT_ALLOWED);
+    }
+}

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormFacadeServiceImpl.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormFacadeServiceImpl.java
@@ -1,11 +1,8 @@
 package kr.mashup.branding.facade.application.form;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
-import kr.mashup.branding.domain.application.Application;
 import kr.mashup.branding.domain.application.ApplicationService;
 import kr.mashup.branding.domain.application.form.ApplicationForm;
 import kr.mashup.branding.domain.application.form.ApplicationFormQueryVo;
@@ -50,13 +47,6 @@ public class ApplicationFormFacadeServiceImpl implements ApplicationFormFacadeSe
         // 개발 환경에서는 설문지 삭제 시도시 지원서를 모두 삭제 후 설문지까지 삭제 한다.
         if (profileFacadeService.isLocal() || profileFacadeService.isDevelop()) {
             applicationService.deleteByApplicationFormId(applicationFormId);
-            applicationFormService.delete(applicationFormId);
-            return;
-        }
-
-        List<Application> applications = applicationService.getApplicationsByFormId(applicationFormId);
-        if (!applications.isEmpty()) {
-            throw new ApplicationFormDeleteFailedException();
         }
         applicationFormService.delete(applicationFormId);
     }

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormFacadeServiceImpl.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/application/form/ApplicationFormFacadeServiceImpl.java
@@ -1,19 +1,26 @@
 package kr.mashup.branding.facade.application.form;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
+import kr.mashup.branding.domain.application.Application;
+import kr.mashup.branding.domain.application.ApplicationService;
 import kr.mashup.branding.domain.application.form.ApplicationForm;
 import kr.mashup.branding.domain.application.form.ApplicationFormQueryVo;
 import kr.mashup.branding.domain.application.form.ApplicationFormService;
 import kr.mashup.branding.domain.application.form.CreateApplicationFormVo;
 import kr.mashup.branding.domain.application.form.UpdateApplicationFormVo;
+import kr.mashup.branding.facade.ProfileFacadeService;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ApplicationFormFacadeServiceImpl implements ApplicationFormFacadeService {
     private final ApplicationFormService applicationFormService;
+    private final ApplicationService applicationService;
+    private final ProfileFacadeService profileFacadeService;
 
     @Override
     public ApplicationForm create(CreateApplicationFormVo createApplicationFormVo) {
@@ -40,6 +47,17 @@ public class ApplicationFormFacadeServiceImpl implements ApplicationFormFacadeSe
 
     @Override
     public void delete(Long applicationFormId) {
+        // 개발 환경에서는 설문지 삭제 시도시 지원서를 모두 삭제 후 설문지까지 삭제 한다.
+        if (profileFacadeService.isLocal() || profileFacadeService.isDevelop()) {
+            applicationService.deleteByApplicationFormId(applicationFormId);
+            applicationFormService.delete(applicationFormId);
+            return;
+        }
+
+        List<Application> applications = applicationService.getApplicationsByFormId(applicationFormId);
+        if (!applications.isEmpty()) {
+            throw new ApplicationFormDeleteFailedException();
+        }
         applicationFormService.delete(applicationFormId);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
@@ -26,6 +26,7 @@ public enum ResultCode {
     APPLICATION_FORM_ALREADY_EXIST("같은 팀에 이미 다른 설문지가 존재합니다."),
     APPLICATION_FORM_MODIFICATION_NOT_ALLOWED("모집 시작시각 이후에는 설문지를 수정하거나 삭제할 수 없습니다"),
     APPLICATION_FORM_NOT_FOUND("설문지가 존재하지 않습니다."),
+    APPLICATION_FORM_DELETE_NOT_ALLOWED("생성된 지원서가 있어 설문지를 삭제 할 수 없습니다."),
 
     // SMS (문자 발송)
     NOTIFICATION_NOT_FOUND("통지 정보가 없습니다."),

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationRepository.java
@@ -15,4 +15,6 @@ interface ApplicationRepository extends JpaRepository<Application, Long>, Applic
     List<Application> findByApplicantAndApplicationForm(Applicant applicant, ApplicationForm applicationForm);
 
     Optional<Application> findByApplicationIdAndApplicant_applicantId(Long applicationId, Long applicantId);
+
+    List<Application> findByApplicationForm_ApplicationFormId(Long applicationFormId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import kr.mashup.branding.domain.applicant.Applicant;
 import kr.mashup.branding.domain.application.form.ApplicationForm;
 
-interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationRepositoryCustom {
+public interface ApplicationRepository extends JpaRepository<Application, Long>, ApplicationRepositoryCustom {
     List<Application> findByApplicant_applicantIdAndStatusIn(Long applicantId, Collection<ApplicationStatus> statuses);
 
     List<Application> findByApplicantAndApplicationForm(Applicant applicant, ApplicationForm applicationForm);
@@ -17,4 +17,6 @@ interface ApplicationRepository extends JpaRepository<Application, Long>, Applic
     Optional<Application> findByApplicationIdAndApplicant_applicantId(Long applicationId, Long applicantId);
 
     List<Application> findByApplicationForm_ApplicationFormId(Long applicationFormId);
+
+    boolean existsByApplicationForm_ApplicationFormId(Long applicationFormId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationService.java
@@ -20,9 +20,13 @@ public interface ApplicationService {
 
     List<Application> getApplications(Long applicantId);
 
+    List<Application> getApplicationsByFormId(Long applicationFormId);
+
     Application getApplication(Long applicantId, Long applicationId);
 
     Application getApplication(Long applicationId);
 
     Page<Application> getApplications(Long adminMemberId, ApplicationQueryVo applicationQueryVo);
+
+    void deleteByApplicationFormId(Long applicationFormId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationService.java
@@ -20,8 +20,6 @@ public interface ApplicationService {
 
     List<Application> getApplications(Long applicantId);
 
-    List<Application> getApplicationsByFormId(Long applicationFormId);
-
     Application getApplication(Long applicantId, Long applicationId);
 
     Application getApplication(Long applicationId);

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationServiceImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import kr.mashup.branding.domain.adminmember.AdminMemberService;
 import kr.mashup.branding.domain.applicant.Applicant;
 import kr.mashup.branding.domain.applicant.ApplicantNotFoundException;
 import kr.mashup.branding.domain.applicant.ApplicantService;
@@ -34,7 +33,6 @@ public class ApplicationServiceImpl implements ApplicationService {
     private final TeamService teamService;
     private final ApplicantService applicantService;
     private final RecruitmentScheduleService recruitmentScheduleService;
-    private final AdminMemberService adminMemberService;
 
     // get or create
     // TODO: 모르겠고 teamId 줄테니 다내놔! 에 대해서 고민해보기
@@ -166,11 +164,6 @@ public class ApplicationServiceImpl implements ApplicationService {
             ApplicationStatus.validSet());
     }
 
-    @Override
-    public List<Application> getApplicationsByFormId(Long applicationFormId) {
-        return applicationRepository.findByApplicationForm_ApplicationFormId(applicationFormId);
-    }
-
     // TODO: 상세 조회시 form 도 같이 조합해서 내려주어야할듯 (teamId, memberId 요청하면 해당팀 쓰던 지원서 질문, 내용 다 합쳐서)
     @Override
     public Application getApplication(Long applicantId, Long applicationId) {
@@ -195,6 +188,7 @@ public class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
+    @Transactional
     public void deleteByApplicationFormId(Long applicationFormId) {
         List<Application> applications = applicationRepository
             .findByApplicationForm_ApplicationFormId(applicationFormId);

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationServiceImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/ApplicationServiceImpl.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.domain.application;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -165,6 +166,11 @@ public class ApplicationServiceImpl implements ApplicationService {
             ApplicationStatus.validSet());
     }
 
+    @Override
+    public List<Application> getApplicationsByFormId(Long applicationFormId) {
+        return applicationRepository.findByApplicationForm_ApplicationFormId(applicationFormId);
+    }
+
     // TODO: 상세 조회시 form 도 같이 조합해서 내려주어야할듯 (teamId, memberId 요청하면 해당팀 쓰던 지원서 질문, 내용 다 합쳐서)
     @Override
     public Application getApplication(Long applicantId, Long applicationId) {
@@ -186,5 +192,17 @@ public class ApplicationServiceImpl implements ApplicationService {
     @Override
     public Page<Application> getApplications(Long adminMemberId, ApplicationQueryVo applicationQueryVo) {
         return applicationRepository.findBy(applicationQueryVo);
+    }
+
+    @Override
+    public void deleteByApplicationFormId(Long applicationFormId) {
+        List<Application> applications = applicationRepository
+            .findByApplicationForm_ApplicationFormId(applicationFormId);
+
+        List<Long> applicationIds = applications.stream()
+            .map(Application::getApplicationId)
+            .collect(Collectors.toList());
+
+        applicationRepository.deleteAllById(applicationIds);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/form/ApplicationFormDeleteFailedException.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/form/ApplicationFormDeleteFailedException.java
@@ -1,4 +1,4 @@
-package kr.mashup.branding.facade.application.form;
+package kr.mashup.branding.domain.application.form;
 
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/application/form/ApplicationFormServiceImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/application/form/ApplicationFormServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.mashup.branding.domain.application.ApplicationRepository;
 import kr.mashup.branding.domain.schedule.RecruitmentScheduleService;
 import kr.mashup.branding.domain.team.Team;
 import kr.mashup.branding.domain.team.TeamService;
@@ -21,6 +22,7 @@ public class ApplicationFormServiceImpl implements ApplicationFormService {
     private final TeamService teamService;
     private final ApplicationFormRepository applicationFormRepository;
     private final RecruitmentScheduleService recruitmentScheduleService;
+    private final ApplicationRepository applicationRepository;
 
     @Override
     @Transactional
@@ -47,8 +49,7 @@ public class ApplicationFormServiceImpl implements ApplicationFormService {
         if (recruitmentScheduleService.isRecruitStarted(LocalDateTime.now())) {
             throw new ApplicationFormModificationNotAllowedException("모집 시작시각 이후에는 지원서를 수정할 수 없습니다");
         }
-        ApplicationForm applicationForm = applicationFormRepository.findByApplicationFormId(
-            applicationFormId)
+        ApplicationForm applicationForm = applicationFormRepository.findByApplicationFormId(applicationFormId)
             .orElseThrow(ApplicationFormNotFoundException::new);
         applicationForm.update(updateApplicationFormVo);
         return applicationForm;
@@ -60,6 +61,11 @@ public class ApplicationFormServiceImpl implements ApplicationFormService {
         if (recruitmentScheduleService.isRecruitStarted(LocalDateTime.now())) {
             throw new ApplicationFormModificationNotAllowedException("모집 시작시각 이후에는 지원서를 삭제할 수 없습니다");
         }
+
+        if (applicationRepository.existsByApplicationForm_ApplicationFormId(applicationFormId)) {
+            throw new ApplicationFormDeleteFailedException();
+        }
+
         applicationFormRepository.findByApplicationFormId(applicationFormId)
             .ifPresent(applicationFormRepository::delete);
     }

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
@@ -13,6 +13,7 @@ import kr.mashup.branding.domain.adminmember.AdminMemberRepository;
 import kr.mashup.branding.domain.adminmember.Position;
 import kr.mashup.branding.domain.applicant.Applicant;
 import kr.mashup.branding.domain.applicant.ApplicantRepository;
+import kr.mashup.branding.domain.application.ApplicationService;
 import kr.mashup.branding.domain.application.form.ApplicationForm;
 import kr.mashup.branding.domain.application.form.ApplicationFormService;
 import kr.mashup.branding.domain.application.form.CreateApplicationFormVo;
@@ -34,6 +35,7 @@ public class TestDataInitializer {
     private final RecruitmentScheduleRepository recruitmentScheduleRepository;
     private final TeamService teamService;
     private final ApplicationFormService applicationFormService;
+    private final ApplicationService applicationService;
     private final ApplicantRepository applicantRepository;
     private final AdminMemberRepository adminMemberRepository;
 
@@ -139,4 +141,20 @@ public class TestDataInitializer {
         );
         return adminMemberRepository.save(testadmin);
     }
+
+    // 테스트용 지원서 생성 (사용하려면 지원기간 validate 해제 해야함)
+    // private Application createApplication(Long applicantId, Long teamId) {
+    //     return applicationService.create(applicantId, new CreateApplicationVo(teamId));
+    // }
+    //
+    // private Application createAnswers(Application application) {
+    //     List<Long> answerIds = application.getAnswers().stream().map(Answer::getAnswerId).collect(Collectors.toList());
+    //     List<AnswerRequestVo> answerRequestVos = answerIds.stream()
+    //         .map(id -> AnswerRequestVo.of(id, "응답"))
+    //         .collect(Collectors.toList());
+    //
+    //     UpdateApplicationVo of = UpdateApplicationVo.of("이름", "01000000000", answerRequestVos, true);
+    //     applicationService.update(application.getApplicationId(), of);
+    //     return application;
+    // }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.infrastructure.data;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
@@ -13,7 +14,12 @@ import kr.mashup.branding.domain.adminmember.AdminMemberRepository;
 import kr.mashup.branding.domain.adminmember.Position;
 import kr.mashup.branding.domain.applicant.Applicant;
 import kr.mashup.branding.domain.applicant.ApplicantRepository;
+import kr.mashup.branding.domain.application.Answer;
+import kr.mashup.branding.domain.application.AnswerRequestVo;
+import kr.mashup.branding.domain.application.Application;
 import kr.mashup.branding.domain.application.ApplicationService;
+import kr.mashup.branding.domain.application.CreateApplicationVo;
+import kr.mashup.branding.domain.application.UpdateApplicationVo;
 import kr.mashup.branding.domain.application.form.ApplicationForm;
 import kr.mashup.branding.domain.application.form.ApplicationFormService;
 import kr.mashup.branding.domain.application.form.CreateApplicationFormVo;
@@ -59,6 +65,9 @@ public class TestDataInitializer {
 
         AdminMember adminMember = createAdminMember();
         log.info("AdminMember is created. adminMember: {}", adminMember);
+
+        // Application application = createApplication(applicant.getApplicantId(), applicationForm.getTeam().getTeamId());
+        // createAnswers(application);
     }
 
     private List<RecruitmentSchedule> createRecruitmentSchedules() {
@@ -143,18 +152,18 @@ public class TestDataInitializer {
     }
 
     // 테스트용 지원서 생성 (사용하려면 지원기간 validate 해제 해야함)
-    // private Application createApplication(Long applicantId, Long teamId) {
-    //     return applicationService.create(applicantId, new CreateApplicationVo(teamId));
-    // }
-    //
-    // private Application createAnswers(Application application) {
-    //     List<Long> answerIds = application.getAnswers().stream().map(Answer::getAnswerId).collect(Collectors.toList());
-    //     List<AnswerRequestVo> answerRequestVos = answerIds.stream()
-    //         .map(id -> AnswerRequestVo.of(id, "응답"))
-    //         .collect(Collectors.toList());
-    //
-    //     UpdateApplicationVo of = UpdateApplicationVo.of("이름", "01000000000", answerRequestVos, true);
-    //     applicationService.update(application.getApplicationId(), of);
-    //     return application;
-    // }
+    private Application createApplication(Long applicantId, Long teamId) {
+        return applicationService.create(applicantId, new CreateApplicationVo(teamId));
+    }
+
+    private Application createAnswers(Application application) {
+        List<Long> answerIds = application.getAnswers().stream().map(Answer::getAnswerId).collect(Collectors.toList());
+        List<AnswerRequestVo> answerRequestVos = answerIds.stream()
+            .map(id -> AnswerRequestVo.of(id, "응답"))
+            .collect(Collectors.toList());
+
+        UpdateApplicationVo of = UpdateApplicationVo.of("이름", "01000000000", answerRequestVos, true);
+        applicationService.update(application.getApplicationId(), of);
+        return application;
+    }
 }


### PR DESCRIPTION
기존 코드에서는 foreign key 때문에 지원서가 있으면 form 삭제가 불가능 했었습니다.
그래서 지원서가 있으면 ApplicationFormDeleteFailedException를 내려주게 수정 했습니다.

local, dev 환경에서는 해당 formId를 갖고 있는 application을 찾아서 먼저 삭제 하고 (이 과정에서 cascade 옵션이 걸려있는 applicationResult, confirmation 등은 함께 삭제됨) form을 삭제 하게 했습니다.
테스트 (O) - 수동 . . .

이게 form을 삭제하기 전에 application을 먼저 삭제 해야해서 전에 이야기했던 삭제 이벤트를 받아서 후처리는 못했고 profile에 따라서 먼제 application을 지울지 여부를 썼는데  그래서 profileFacadeService를 추가 했습니다 🙇‍♂️