### PR TITLE
feat: 일정검증 무시하게하는 profile 이름 변경

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/data/TestDataInitializer.java
@@ -68,8 +68,13 @@ public class TestDataInitializer {
         Applicant applicant = createApplicant();
         log.info("Applicant is created. applicant: {}", applicant);
 
-        Application application = createApplication(applicant.getApplicantId(), applicationForm.getTeam().getTeamId());
-        log.info("Application is created. application: {}", application);
+        try {
+            Application application = createApplication(applicant.getApplicantId(),
+                applicationForm.getTeam().getTeamId());
+            log.info("Application is created. application: {}", application);
+        } catch (Exception e) {
+            log.info("Failed to created application for test data. message: {}", e.getMessage());
+        }
     }
 
     private List<RecruitmentSchedule> createRecruitmentSchedules() {

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/test/NoopApplicationFormScheduleValidator.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/test/NoopApplicationFormScheduleValidator.java
@@ -10,7 +10,7 @@ import kr.mashup.branding.domain.application.form.ApplicationFormScheduleValidat
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Profile({"local", "develop"})
+@Profile("ignore-schedule-validation")
 @Primary
 @Component
 public class NoopApplicationFormScheduleValidator implements ApplicationFormScheduleValidator {

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/test/NoopApplicationScheduleValidator.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/test/NoopApplicationScheduleValidator.java
@@ -10,7 +10,7 @@ import kr.mashup.branding.domain.application.ApplicationScheduleValidator;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Profile({"local", "develop"})
+@Profile("ignore-schedule-validation")
 @Primary
 @Component
 public class NoopApplicationScheduleValidator implements ApplicationScheduleValidator {


### PR DESCRIPTION
### AS-IS
`local`, `develop` 프로필이 활성화되어있으면 일정관련 검증 무시

### TO-BE
`ignore-schedule-validation` 프로필이 활성화되어있으면 일정 관련 검증 무시