### PR TITLE
feat: response body xss 처리

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ jasyptVersion=3.0.3
 javaJwtVersion=3.18.3
 mysqlVersion=8.0.27
 googleApiClientVersion=1.32.1
+commonsTextVersion=1.9

--- a/mashup-admin/build.gradle
+++ b/mashup-admin/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation "io.springfox:springfox-boot-starter:$swaggerVersion"
+    implementation "org.apache.commons:commons-text:$commonsTextVersion"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/mashup-admin/src/main/java/kr/mashup/branding/config/messageconverter/HTMLCharacterEscapes.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/config/messageconverter/HTMLCharacterEscapes.java
@@ -1,0 +1,34 @@
+package kr.mashup.branding.config.messageconverter;
+
+import org.apache.commons.text.StringEscapeUtils;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+
+public class HTMLCharacterEscapes extends CharacterEscapes {
+
+    private final int[] asciiEscapes;
+
+    public HTMLCharacterEscapes() {
+        asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+        asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['>'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['&'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\"'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['('] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes[')'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['#'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\''] = CharacterEscapes.ESCAPE_CUSTOM;
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii() {
+        return asciiEscapes;
+    }
+
+    @Override
+    public SerializableString getEscapeSequence(int ch) {
+        return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString((char)ch)));
+    }
+}

--- a/mashup-admin/src/main/java/kr/mashup/branding/config/messageconverter/MessageConverterConfig.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/config/messageconverter/MessageConverterConfig.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.config.messageconverter;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class MessageConverterConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public MappingJackson2HttpMessageConverter htmlEscapeConverter() {
+        objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());
+        return new MappingJackson2HttpMessageConverter(objectMapper);
+    }
+}

--- a/mashup-api/build.gradle
+++ b/mashup-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation "io.springfox:springfox-boot-starter:$swaggerVersion"
+    implementation "org.apache.commons:commons-text:$commonsTextVersion"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/mashup-api/src/main/java/kr/mashup/branding/config/messageconverter/HTMLCharacterEscapes.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/config/messageconverter/HTMLCharacterEscapes.java
@@ -1,0 +1,34 @@
+package kr.mashup.branding.config.messageconverter;
+
+import org.apache.commons.text.StringEscapeUtils;
+
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.CharacterEscapes;
+import com.fasterxml.jackson.core.io.SerializedString;
+
+public class HTMLCharacterEscapes extends CharacterEscapes {
+
+    private final int[] asciiEscapes;
+
+    public HTMLCharacterEscapes() {
+        asciiEscapes = CharacterEscapes.standardAsciiEscapesForJSON();
+        asciiEscapes['<'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['>'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['&'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\"'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['('] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes[')'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['#'] = CharacterEscapes.ESCAPE_CUSTOM;
+        asciiEscapes['\''] = CharacterEscapes.ESCAPE_CUSTOM;
+    }
+
+    @Override
+    public int[] getEscapeCodesForAscii() {
+        return asciiEscapes;
+    }
+
+    @Override
+    public SerializableString getEscapeSequence(int ch) {
+        return new SerializedString(StringEscapeUtils.escapeHtml4(Character.toString((char)ch)));
+    }
+}

--- a/mashup-api/src/main/java/kr/mashup/branding/config/messageconverter/MessageConverterConfig.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/config/messageconverter/MessageConverterConfig.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.config.messageconverter;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class MessageConverterConfig {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public MappingJackson2HttpMessageConverter htmlEscapeConverter() {
+        objectMapper.getFactory().setCharacterEscapes(new HTMLCharacterEscapes());
+        return new MappingJackson2HttpMessageConverter(objectMapper);
+    }
+}

--- a/mashup-api/src/test/java/kr/mashup/branding/ui/team/TeamControllerTest.java
+++ b/mashup-api/src/test/java/kr/mashup/branding/ui/team/TeamControllerTest.java
@@ -61,7 +61,7 @@ class TeamControllerTest {
         assertThat(teamNames).contains("Design", "Android", "iOS", "Web", "Node", "Spring");
     }
 
-    @DisplayName("팀 이름으로 XSS 방지 테스트")
+    @DisplayName("데이터에 스크립트가 포함되었을 때 응답에 스크립트 인코딩")
     @Test
     void getTeamXss() throws Exception {
         // given


### PR DESCRIPTION
- HTML 태그 인코딩 기능 도움 받기 위해 org.apache.commons:commons-text 추가 
- 기존 ObjectMappter에 HTMLCharacterEscapes를 추가하여 MappingJackson2HttpMessageConverter 생성 후 빈으로 등록
- 테스트O