### PR TITLE
fix: 지원서 임시저장 상태에서 최종 발표 시간 이후 상태에 대한 이슈 해결

### DIFF
--- a/mashup-api/src/main/java/kr/mashup/branding/ui/application/ApplicationStatusResponse.java
+++ b/mashup-api/src/main/java/kr/mashup/branding/ui/application/ApplicationStatusResponse.java
@@ -37,7 +37,7 @@ public enum ApplicationStatusResponse {
         ApplicationStatus applicationStatus,
         ApplicationScreeningStatus screeningStatus
     ) {
-        if (applicationStatus == ApplicationStatus.WRITING) {
+        if (applicationStatus == ApplicationStatus.WRITING || screeningStatus == ApplicationScreeningStatus.NOT_RATED) {
             return SCREENING_EXPIRED;
         }
         if (screeningStatus == ApplicationScreeningStatus.PASSED) {
@@ -53,7 +53,10 @@ public enum ApplicationStatusResponse {
         ApplicationScreeningStatus screeningStatus,
         ApplicationInterviewStatus interviewStatus
     ) {
-        if (screeningStatus == ApplicationScreeningStatus.FAILED) {
+        if (screeningStatus == ApplicationScreeningStatus.NOT_RATED || interviewStatus == ApplicationInterviewStatus.NOT_RATED) {
+            return SCREENING_EXPIRED;
+        }
+        if (screeningStatus == ApplicationScreeningStatus.FAILED || interviewStatus == ApplicationInterviewStatus.NOT_APPLICABLE) {
             return SCREENING_FAILED;
         }
         if (interviewStatus == ApplicationInterviewStatus.PASSED) {


### PR DESCRIPTION
- 문제 상황 : 최종 발표 시간 이후 면접 불합격 상태가 내려옴
- 정상적인 상황 : 최종 발표 시간 이후 기한 만료 상태가 내려옴
미검토 케이스를 추가하여 문제 해결