### PR TITLE
feat: 지원서 디테일 응답에 문자 발송 시각 넣기

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/notification/sms/SmsRequestAssembler.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/notification/sms/SmsRequestAssembler.java
@@ -34,6 +34,7 @@ public class SmsRequestAssembler {
             smsRequest.getNotification().getSender().getPosition(),
             smsRequest.getNotification().getContent(),
             smsRequest.getStatus(),
+            smsRequest.getCreatedAt(),
             teamAssembler.toTeamResponse(team)
         );
     }

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/notification/sms/SmsRequestDetailResponse.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/notification/sms/SmsRequestDetailResponse.java
@@ -7,6 +7,8 @@ import kr.mashup.branding.ui.team.TeamResponse;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 @AllArgsConstructor
 public class SmsRequestDetailResponse {
@@ -27,6 +29,9 @@ public class SmsRequestDetailResponse {
 
     @ApiModelProperty(value = "발송 상태(성공, 실패)", example = "SUCCESS")
     private SmsNotificationStatus status;
+
+    @ApiModelProperty(value = "발송(생성) 날짜 및 시간")
+    private LocalDateTime createdAt;
 
     @ApiModelProperty(value = "수신자 지원 플랫폼")
     private TeamResponse team;


### PR DESCRIPTION
* 지원서 디테일에서 문자 발송 내역의 생성 시간 추가
  * sms-request에는 sentAt은 없고 createdAt, updatedAt만 존재
  * 따라서, 생성 시점을 보냄

* 관련 QA 
  * https://www.notion.so/SMS-c6ba9da496114f878396c137ad65c9a0