### PR TITLE
feat: security config 설정

### DIFF
--- a/mashup-member/build.gradle
+++ b/mashup-member/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     // auth
     implementation "com.auth0:java-jwt:$javaJwtVersion"
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // swagger
     implementation "io.springfox:springfox-boot-starter:$swaggerVersion"

--- a/mashup-member/src/main/java/kr/mashup/branding/security/SecurityConfig.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/security/SecurityConfig.java
@@ -1,0 +1,95 @@
+package kr.mashup.branding.security;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import kr.mashup.branding.domain.ResultCode;
+import kr.mashup.branding.domain.adminmember.Position;
+import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.ui.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    public static final String[] AUTHORITY_NAMES = Arrays.stream(Platform.values()).map(Enum::name)
+        .collect(Collectors.toList()).toArray(new String[Position.values().length]);
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.antMatcher("/api/v1/**")
+            .authorizeRequests()
+            .antMatchers("/api/v1/members/signup").permitAll()
+            .antMatchers("/api/v1/members/login").permitAll()
+            .antMatchers("/api/v1/members/code").permitAll()
+            .anyRequest().hasAnyAuthority(AUTHORITY_NAMES);
+        http.cors().configurationSource(corsConfigurationSource());
+        http.csrf().disable()
+            .logout().disable()
+            .formLogin().disable()
+            .httpBasic().disable()
+            .requestCache().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint((request, response, authException) -> {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                objectMapper.writeValue(
+                    response.getOutputStream(),
+                    ApiResponse.failure(ResultCode.UNAUTHORIZED)
+                );
+            })
+            .accessDeniedHandler((request, response, accessDeniedException) -> {
+                response.setStatus(HttpStatus.FORBIDDEN.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                objectMapper.writeValue(
+                    response.getOutputStream(),
+                    ApiResponse.failure(ResultCode.FORBIDDEN)
+                );
+            });
+    }
+
+    @Override
+    public void configure(WebSecurity webSecurity) {
+        webSecurity.ignoring().antMatchers(
+            "/h2-console/**",
+            "/error",
+            "/favicon.ico",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v2/api-docs",
+            "/hello"
+        );
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}


### PR DESCRIPTION
## 변경사항

### security config 설정 추가
아래 3개의 API 제외한 모든 API는 요청 시에 엑세스 토큰이 필요하도록 설정하였습니다.
- 회원가입 API
- 로그인 API
- 회원가입 코드 검증 API