### PR TITLE
feat: 스케줄 조회 시, 스케줄 진행 상황 및 남은 기간 필드 추가

### DIFF
--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -25,9 +25,9 @@ public class ScheduleFacadeService {
 
     public ScheduleResponse getById(Long id) {
         Schedule schedule = scheduleService.getByIdOrThrow(id);
-        Integer dayCount = countDate(schedule.getStartedAt(), LocalDateTime.now());
+        Integer dateCount = countDate(schedule.getStartedAt(), LocalDateTime.now());
 
-        return ScheduleResponse.from(schedule, dayCount);
+        return ScheduleResponse.from(schedule, dateCount);
     }
 
     public ScheduleResponseList getByGenerationNum(Integer number) {
@@ -64,8 +64,8 @@ public class ScheduleFacadeService {
         Integer dateCount = 0;
 
         for (ScheduleResponse scheduleResponse : scheduleResponseList) {
-            if (scheduleResponse.getDatCount() > 0) {
-                dateCount = scheduleResponse.getDatCount();
+            if (scheduleResponse.getDateCount() > 0) {
+                dateCount = scheduleResponse.getDateCount();
                 break;
             }
         }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -1,5 +1,7 @@
 package kr.mashup.branding.facade.schedule;
 
+import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,7 +11,10 @@ import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.service.generation.GenerationService;
 import kr.mashup.branding.service.schedule.ScheduleService;
+import kr.mashup.branding.ui.schedule.response.Progress;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponse;
+import kr.mashup.branding.ui.schedule.response.ScheduleResponseListWithProgress;
+import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,13 +30,51 @@ public class ScheduleFacadeService {
         return ScheduleResponse.from(schedule);
     }
 
-    public List<ScheduleResponse> getByGenerationNum(Integer number) {
+    public ScheduleResponseListWithProgress getByGenerationNum(Integer number) {
         Generation generation = generationService.getByNumberOrThrow(number);
 
         List<Schedule> scheduleList = scheduleService.getByGeneration(generation);
+        Progress progress;
+        Integer dateCount = calculateDateCount(scheduleList);
 
-        return scheduleList.stream()
+        if (scheduleList.size() == 0) {
+            progress = Progress.NOT_REGISTER;
+        } else if (dateCount == -1L) {
+            progress = Progress.DONE;
+        } else {
+            progress = Progress.ON_GOING;
+        }
+
+        List<ScheduleResponse> scheduleResponseList = scheduleList.stream()
             .map(ScheduleResponse::from)
             .collect(Collectors.toList());
+
+        return ScheduleResponseListWithProgress.of(progress, dateCount, scheduleResponseList);
+    }
+
+    private Integer calculateDateCount(List<Schedule> scheduleList) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        Integer dateCount = -1;
+
+        int listSize = scheduleList.size();
+        for (int i = listSize - 1; i > 0; i--) {
+            LocalDateTime startedAt = scheduleList.get(i).getStartedAt();
+            LocalDateTime endedAt = scheduleList.get(i).getEndedAt();
+
+            if (isFinishedSchedule(currentTime, endedAt) || isOngoingSchedule(startedAt, endedAt, currentTime)) {
+                break;
+            }
+            dateCount = Period.between(currentTime.toLocalDate(), startedAt.toLocalDate()).getDays();
+        }
+
+        return dateCount;
+    }
+
+    private Boolean isFinishedSchedule(LocalDateTime now, LocalDateTime endedAt) {
+        return now.isAfter(endedAt);
+    }
+
+    private Boolean isOngoingSchedule(LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime now) {
+        return DateUtil.isInTime(startedAt, endedAt, now);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
@@ -9,7 +9,7 @@ import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.schedule.ScheduleFacadeService;
 import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponse;
-import kr.mashup.branding.ui.schedule.response.ScheduleResponseListWithProgress;
+import kr.mashup.branding.ui.schedule.response.ScheduleResponseList;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -29,10 +29,10 @@ public class ScheduleController {
 
     @ApiOperation("기수로 스케줄 조회")
     @GetMapping("/generations/{generationNumber}")
-    public ApiResponse<ScheduleResponseListWithProgress> getByGenerationNumber(
+    public ApiResponse<ScheduleResponseList> getByGenerationNumber(
         @PathVariable Integer generationNumber
     ) {
-        ScheduleResponseListWithProgress res =
+        ScheduleResponseList res =
             scheduleFacadeService.getByGenerationNum(generationNumber);
 
         return ApiResponse.success(res);

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
@@ -1,7 +1,5 @@
 package kr.mashup.branding.ui.schedule;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +9,7 @@ import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.schedule.ScheduleFacadeService;
 import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponse;
+import kr.mashup.branding.ui.schedule.response.ScheduleResponseListWithProgress;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -30,10 +29,10 @@ public class ScheduleController {
 
     @ApiOperation("기수로 스케줄 조회")
     @GetMapping("/generations/{generationNumber}")
-    public ApiResponse<List<ScheduleResponse>> getByGenerationNumber(
+    public ApiResponse<ScheduleResponseListWithProgress> getByGenerationNumber(
         @PathVariable Integer generationNumber
     ) {
-        List<ScheduleResponse> res =
+        ScheduleResponseListWithProgress res =
             scheduleFacadeService.getByGenerationNum(generationNumber);
 
         return ApiResponse.success(res);

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/Progress.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/Progress.java
@@ -1,0 +1,7 @@
+package kr.mashup.branding.ui.schedule.response;
+
+public enum Progress {
+    NOT_REGISTER, // 등록된 세미나가 없는 경우
+    ON_GOING, // 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 있는 경우
+    DONE; // 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 없는 경우
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/Progress.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/Progress.java
@@ -1,7 +1,7 @@
 package kr.mashup.branding.ui.schedule.response;
 
 public enum Progress {
-    NOT_REGISTER, // 등록된 세미나가 없는 경우
+    NOT_REGISTERED, // 등록된 세미나가 없는 경우
     ON_GOING, // 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 있는 경우
     DONE; // 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 없는 경우
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -16,6 +16,8 @@ public class ScheduleResponse {
 
     String name;
 
+    Integer datCount;
+
     LocalDateTime startedAt;
 
     LocalDateTime endedAt;
@@ -24,10 +26,11 @@ public class ScheduleResponse {
 
     List<EventResponse> eventList;
 
-    public static ScheduleResponse from(Schedule schedule) {
+    public static ScheduleResponse from(Schedule schedule, Integer dayCount) {
         return ScheduleResponse.of(
             schedule.getId(),
             schedule.getName(),
+            dayCount,
             schedule.getStartedAt(),
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -16,7 +16,7 @@ public class ScheduleResponse {
 
     String name;
 
-    Integer datCount;
+    Integer dateCount;
 
     LocalDateTime startedAt;
 
@@ -26,11 +26,11 @@ public class ScheduleResponse {
 
     List<EventResponse> eventList;
 
-    public static ScheduleResponse from(Schedule schedule, Integer dayCount) {
+    public static ScheduleResponse from(Schedule schedule, Integer dateCount) {
         return ScheduleResponse.of(
             schedule.getId(),
             schedule.getName(),
-            dayCount,
+            dateCount,
             schedule.getStartedAt(),
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseList.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseList.java
@@ -7,7 +7,7 @@ import lombok.Value;
 
 @Getter
 @Value(staticConstructor = "of")
-public class ScheduleResponseListWithProgress {
+public class ScheduleResponseList {
 
     Progress progress;
 

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseListWithProgress.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseListWithProgress.java
@@ -1,0 +1,17 @@
+package kr.mashup.branding.ui.schedule.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Value;
+
+@Getter
+@Value(staticConstructor = "of")
+public class ScheduleResponseListWithProgress {
+
+    Progress progress;
+
+    Long dateCount;
+
+    List<ScheduleResponse> scheduleList;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseListWithProgress.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponseListWithProgress.java
@@ -11,7 +11,7 @@ public class ScheduleResponseListWithProgress {
 
     Progress progress;
 
-    Long dateCount;
+    Integer dateCount;
 
     List<ScheduleResponse> scheduleList;
 }


### PR DESCRIPTION
## 변경사항

### 스케줄 조회 시, 스케줄 진행 상황 및 남은 기간 필드 추가
![image](https://user-images.githubusercontent.com/66551410/182013394-ca08a6f9-08d4-4770-8cd1-5dbb288bdb79.png)

### 스케줄 진행 상황
- NOT_REGISTERED: 등록된 세미나가 없는 경우
- ON_GOING: 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 있는 경우
- DONE: 세미나가 존재하지만, 현재 날짜 이후로 등록된 세미나가 없는 경우

### 남은 기간 필드(dateCount)
- 과거 스케줄인 경우: 음수값(-) 표시
- 현재 스케줄인 경우: 0 표시
- 미래 스케줄인 경우: 양수값(+) 표시

### id로 스케줄 조회 응답값 예시
```
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "scheduleId": 3,
    "name": "해커톤",
    "dateCount": -3,
    "startedAt": "2022-07-28T23:59:00",
    "endedAt": "2022-07-28T23:59:00",
    "generationNumber": 1,
  }
}
```

### generationId로 스케줄 조회 응답값 예시
```
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "progress": "DONE",
    "dateCount": 0,
    "scheduleList": [
      {
        "scheduleId": 1,
        "name": "1차 정기 세미나",
        "datCount": -29,
        "startedAt": "2021-07-02T15:30:00",
        "endedAt": "2021-07-02T16:30:00",
        "generationNumber": 1,
        "eventList": [
          {
            "eventId": 1,
            "startedAt": "2022-05-02T15:30:00",
            "endedAt": "2022-10-02T16:00:00",
```