### PR TITLE
푸시 알림 정보 업데이트 및 조회 추가

### DIFF
--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
@@ -84,6 +84,9 @@ public class MemberFacadeService {
         final String token = jwtService.encode(member.getId());
         Platform latestPlatform = memberService.getLatestPlatform(member);
 
+        // 회원가입 시점에 푸시 알림을 위한 정보 업데이트
+        memberService.updatePushNotificationInfo(request.getOsType(), request.getFcmToken(), member);
+
         return AccessResponse.of(member,latestPlatform, token);
     }
 

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/SignUpRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/SignUpRequest.java
@@ -1,11 +1,13 @@
 package kr.mashup.branding.ui.member.request;
 
+import kr.mashup.branding.domain.member.OsType;
 import kr.mashup.branding.domain.member.Platform;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -28,4 +30,10 @@ public class SignUpRequest {
 
     @AssertTrue(message = "개인정보 이용에 동의해야 가입할 수 있습니다.")
     private Boolean privatePolicyAgreed;
+
+    @NotNull
+    private OsType osType;
+
+    @NotEmpty
+    private String fcmToken;
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberInfoResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberInfoResponse.java
@@ -22,6 +22,8 @@ public class MemberInfoResponse {
 
     private List<Integer> generations;
 
+    private Boolean pushNotificationAgreed;
+
     public static MemberInfoResponse from(Member member, Platform platform) {
         return MemberInfoResponse.of(
                 member.getId(),
@@ -31,7 +33,8 @@ public class MemberInfoResponse {
                 member.getMemberGenerations()
                         .stream()
                         .map(it -> it.getGeneration().getNumber())
-                        .collect(Collectors.toList())
+                        .collect(Collectors.toList()),
+                member.getPushNotificationAgreed()
         );
     }
 


### PR DESCRIPTION
## 작업사항

### 푸시 알림 정보 업데이트 시점 추가
- 회원가입 시에도 osType, fcmToken 정보를 업데이트 할 수 있도록 추가합니다.

### 회원 정보 조회 시에, 푸시 알림 동의 여부 필드 추가