### PR TITLE
스케줄 조회 시, 상태값 추가

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -42,7 +42,7 @@ public class ScheduleFacadeService {
                 = generationService.getByNumberOrThrow(generationNumber);
 
         return scheduleService
-                .getByGeneration(generation, pageable)
+                .getByGeneration(generation, null, pageable)
                 .map(ScheduleResponse::from);
     }
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -1,19 +1,20 @@
 package kr.mashup.branding.repository.schedule;
 
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
 
     @Query("SELECT s FROM Schedule s WHERE s.isCounted = :isCounted")
     List<Schedule> findAllByIsCounted(@Param("isCounted") boolean isCounted);
 
-    Schedule findByStartedAt(LocalDateTime startedAt);
+    Optional<Schedule> findByIdAndStatus(Long id, ScheduleStatus status);
 }
 /**
  * Schedule 연관관계

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.repository.schedule;
 
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,7 +11,7 @@ import java.util.Optional;
 
 public interface ScheduleRepositoryCustom {
 
-    Page<Schedule> findByGeneration(Generation generation, Pageable pageable);
+    Page<Schedule> findByGeneration(Generation generation, ScheduleStatus status, Pageable pageable);
 
     Optional<Schedule> retrieveByStartDate(LocalDate startDate);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -5,12 +5,7 @@ import kr.mashup.branding.domain.attendance.AttendanceCode;
 import kr.mashup.branding.domain.exception.NotFoundException;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.*;
-import kr.mashup.branding.domain.schedule.exception.CodeGenerateFailException;
-import kr.mashup.branding.domain.schedule.exception.EventNotFoundException;
-import kr.mashup.branding.domain.schedule.exception.ScheduleAlreadyPublishedException;
-import kr.mashup.branding.domain.schedule.exception.ScheduleNotDeletableException;
-import kr.mashup.branding.domain.schedule.exception.ScheduleNotFoundException;
-import kr.mashup.branding.domain.schedule.exception.ScheduleNotDeletableException;
+import kr.mashup.branding.domain.schedule.exception.*;
 import kr.mashup.branding.repository.attendancecode.AttendanceCodeRepository;
 import kr.mashup.branding.repository.schedule.ScheduleRepository;
 import kr.mashup.branding.util.DateRange;
@@ -40,14 +35,18 @@ public class ScheduleService {
             .orElseThrow(() -> new NotFoundException(ResultCode.SCHEDULE_NOT_FOUND));
     }
 
-    public List<Schedule> getByGeneration(Generation generation) {
-        return scheduleRepository.findByGeneration(generation, Pageable.unpaged()).toList();
+    public Schedule getByIdAndStatusOrThrow(Long scheduleId, ScheduleStatus status) {
+        return scheduleRepository.findByIdAndStatus(scheduleId, status)
+                .orElseThrow(() -> new NotFoundException(ResultCode.SCHEDULE_NOT_FOUND));
     }
 
+    public List<Schedule> getByGenerationAndStatus(Generation generation, ScheduleStatus status) {
+        return scheduleRepository.findByGeneration(generation, status, Pageable.unpaged()).toList();
+    }
 
-    public Page<Schedule> getByGeneration(Generation generation, Pageable pageable) {
+    public Page<Schedule> getByGeneration(Generation generation, ScheduleStatus status, Pageable pageable) {
         return scheduleRepository
-            .findByGeneration(generation, pageable);
+            .findByGeneration(generation, status, pageable);
     }
 
     public Event addEvents(Schedule schedule, EventCreateDto dto) {

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -16,6 +16,7 @@ import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartedVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartingVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
 import kr.mashup.branding.service.attendance.AttendanceCodeService;
 import kr.mashup.branding.service.attendance.AttendanceService;
@@ -207,7 +208,7 @@ public class AttendanceFacadeService {
     public TotalAttendanceResponse getTotalAttendance(Long scheduleId) {
 
         final LocalDateTime now = LocalDateTime.now();
-        final Schedule schedule = scheduleService.getByIdOrThrow(scheduleId);
+        final Schedule schedule = scheduleService.getByIdAndStatusOrThrow(scheduleId, ScheduleStatus.PUBLIC);
         final Generation currentGeneration = schedule.getGeneration();
 
         final List<Event> startedEvents =
@@ -301,7 +302,7 @@ public class AttendanceFacadeService {
             Platform platform,
             Long scheduleId
     ) {
-        final Schedule schedule = scheduleService.getByIdOrThrow(scheduleId);
+        final Schedule schedule = scheduleService.getByIdAndStatusOrThrow(scheduleId, ScheduleStatus.PUBLIC);
         final Generation currentGeneration = schedule.getGeneration();
 
         final List<Member> members =
@@ -334,7 +335,7 @@ public class AttendanceFacadeService {
             Long scheduleId
     ) {
         final Member member = memberService.getActiveOrThrowById(memberId);
-        final Schedule schedule = scheduleService.getByIdOrThrow(scheduleId);
+        final Schedule schedule = scheduleService.getByIdAndStatusOrThrow(scheduleId, ScheduleStatus.PUBLIC);
 
         final List<AttendanceInfo> attendanceInfos =
                 getAttendanceInfoByMember(

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.facade.schedule;
 
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import kr.mashup.branding.service.generation.GenerationService;
 import kr.mashup.branding.service.schedule.ScheduleService;
 import kr.mashup.branding.ui.schedule.response.Progress;
@@ -25,7 +26,7 @@ public class ScheduleFacadeService {
 
     @Transactional(readOnly = true)
     public ScheduleResponse getById(Long id) {
-        Schedule schedule = scheduleService.getByIdOrThrow(id);
+        Schedule schedule = scheduleService.getByIdAndStatusOrThrow(id, ScheduleStatus.PUBLIC);
         Integer dateCount = countDate(schedule.getStartedAt(), LocalDateTime.now());
 
         return ScheduleResponse.from(schedule, dateCount);
@@ -35,7 +36,7 @@ public class ScheduleFacadeService {
     public ScheduleResponseList getByGenerationNum(Integer number) {
         Generation generation = generationService.getByNumberOrThrow(number);
 
-        List<Schedule> scheduleList = scheduleService.getByGeneration(generation);
+        List<Schedule> scheduleList = scheduleService.getByGenerationAndStatus(generation, ScheduleStatus.PUBLIC);
 
         LocalDateTime currentTIme = LocalDateTime.now();
         List<ScheduleResponse> scheduleResponseList = scheduleList.stream()


### PR DESCRIPTION
## PR 타입
- 기능 수정

## 개요
- 스케줄 상태값(`PUBLIC`, `ADMIN_ONLY`) 이 추가되었습니다.
- 멤버 모듈에서는 `PUBLIC` 상태인 스케줄만 조회하도록 변경하였습니다.

##  변경사항
- 스케줄 단건 조회 시에 상태값을 포함하여 조회하는 메서드 추가
- 스케줄 다건 조회 시이 상태값이 있으면 해당 상태값만 / 없으면 모든 상태값 조회 하도록 조건 수정
