### PR TITLE
출석체크 없는 경우에 결석 처리 로직 추가

### DIFF
--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -4,11 +4,14 @@ import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.scorehistory.ScoreHistory;
+import kr.mashup.branding.domain.scorehistory.ScoreType;
 import kr.mashup.branding.service.attendance.AttendanceService;
+import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.schedule.ScheduleService;
 import kr.mashup.branding.service.scorehistory.ScoreHistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -22,23 +25,48 @@ public class ScoreHistoryFacadeService {
     private final ScheduleService scheduleService;
     private final AttendanceService attendanceService;
     private final ScoreHistoryService scoreHistoryService;
+    private final MemberService memberService;
 
-    // TODO: 리팩토링 진행 by @hocaron
+    @Transactional
     public List<Member> create() {
         List<Schedule> schedules = scheduleService.findAllByIsCounted(false);
-        List<Member> members = new ArrayList<>();
+        List<Member> updatedMember = new ArrayList<>();
 
         schedules.forEach(schedule -> {
-            Map<Member, List<Attendance>> attendanceMap = attendanceService.getByScheduleAndGroupByMember(schedule);
-            attendanceMap.forEach((member, attendances) -> {
-                ScoreHistory scoreHistory = scoreHistoryService.createByAttendances(member, schedule, attendances);
-                scoreHistoryService.save(scoreHistory);
-                members.add(member);
-            });
+            List<Member> members = memberService.getActiveAllByGeneration(schedule.getGeneration());
+
+            List<ScoreHistory> scoreHistories = new ArrayList<>();
+            scoreHistories.addAll(getCheckedAttendance(schedule, members));
+            scoreHistories.addAll(getUnCheckedAttendance(schedule, members));
+            scoreHistoryService.saveAll(scoreHistories);
+
             schedule.changeIsCounted(true);
+
+            updatedMember.removeAll(members);
+            updatedMember.addAll(members);
         });
-        return members;
+        return updatedMember;
     }
+
+    private List<ScoreHistory> getCheckedAttendance(Schedule schedule, List<Member> members) {
+        Map<Member, List<Attendance>> checkedAttendances = attendanceService.getByScheduleAndGroupByMember(schedule);
+
+        List<ScoreHistory> scoreHistories = new ArrayList<>();
+        checkedAttendances.forEach((member, attendances) -> {
+            scoreHistories.add(scoreHistoryService.createByAttendances(member, schedule, attendances));
+            members.remove(member);
+        });
+        return scoreHistories;
+    }
+
+    private List<ScoreHistory> getUnCheckedAttendance(Schedule schedule, List<Member> members) {
+        List<ScoreHistory> scoreHistories = new ArrayList<>();
+        members.forEach((member) ->
+            scoreHistories.add(ScoreHistory.of(ScoreType.ABSENT, schedule, member))
+        );
+        return scoreHistories;
+    }
+
 
     public void delete(LocalDate scheduleStartDate) {
         Schedule schedule = scheduleService.findByStartDate(scheduleStartDate);

--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,10 +48,12 @@ public class ScoreHistoryFacadeService {
 
             schedule.changeIsCounted(true);
 
-            updatedMember.removeAll(members);
             updatedMember.addAll(members);
         });
-        return updatedMember;
+
+        return updatedMember.stream()
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     /**

--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -27,6 +27,11 @@ public class ScoreHistoryFacadeService {
     private final ScoreHistoryService scoreHistoryService;
     private final MemberService memberService;
 
+    /**
+     * 출석점수 집계를 실행합니다.
+     *
+     * @return 출석점수가 업데이트된 member 리스트
+     */
     @Transactional
     public List<Member> create() {
         List<Schedule> schedules = scheduleService.findAllByIsCounted(false);
@@ -48,6 +53,13 @@ public class ScoreHistoryFacadeService {
         return updatedMember;
     }
 
+    /**
+     * attendance 가 있는 member 의 출석점수를 계산합니다.
+     *
+     * @param schedule 출석점수 집계할 스케줄
+     * @param members 출석체크한 멤버
+     * @return 출석점수 리스트
+     */
     private List<ScoreHistory> getCheckedAttendance(Schedule schedule, List<Member> members) {
         Map<Member, List<Attendance>> checkedAttendances = attendanceService.getByScheduleAndGroupByMember(schedule);
 
@@ -59,6 +71,13 @@ public class ScoreHistoryFacadeService {
         return scoreHistories;
     }
 
+    /**
+     * attendance 가 없는 member 의 출석점수(결석처리)를 계산합니다.
+     *
+     * @param schedule 출석점수 집계할 스케줄
+     * @param members 출석체크를 한번도 하지않은 멤버
+     * @return 출석점수 리스트
+     */
     private List<ScoreHistory> getUnCheckedAttendance(Schedule schedule, List<Member> members) {
         List<ScoreHistory> scoreHistories = new ArrayList<>();
         members.forEach((member) ->
@@ -68,6 +87,11 @@ public class ScoreHistoryFacadeService {
     }
 
 
+    /**
+     * schedule 의 startDate 기준으로 출석점수 집계 결과를 삭제합니다.
+     *
+     * @param scheduleStartDate
+     */
     public void delete(LocalDate scheduleStartDate) {
         Schedule schedule = scheduleService.findByStartDate(scheduleStartDate);
         List<ScoreHistory> scoreHistories = scoreHistoryService.findAttendanceScoreByDate(scheduleStartDate);

--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -14,10 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +33,7 @@ public class ScoreHistoryFacadeService {
     @Transactional
     public List<Member> create() {
         List<Schedule> schedules = scheduleService.findAllByIsCounted(false);
-        List<Member> updatedMember = new ArrayList<>();
+        Set<Member> updatedMember = new HashSet<>();
 
         schedules.forEach(schedule -> {
             List<Member> members = memberService.getActiveAllByGeneration(schedule.getGeneration());
@@ -51,9 +48,7 @@ public class ScoreHistoryFacadeService {
             updatedMember.addAll(members);
         });
 
-        return updatedMember.stream()
-                .distinct()
-                .collect(Collectors.toList());
+        return List.copyOf(updatedMember);
     }
 
     /**

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/attendance/CustomAttendanceRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/attendance/CustomAttendanceRepository.java
@@ -1,13 +1,12 @@
 package kr.mashup.branding.repository.attendance;
 
-import java.util.List;
-
-import org.springframework.stereotype.Repository;
-
 import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.schedule.Schedule;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CustomAttendanceRepository {
-	List<Attendance> getBySchedule(Schedule schedule);
+	List<Attendance> findBySchedule(Schedule schedule);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/attendance/CustomAttendanceRepositoryImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/attendance/CustomAttendanceRepositoryImpl.java
@@ -1,15 +1,14 @@
 package kr.mashup.branding.repository.attendance;
 
-import java.util.List;
-
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.attendance.QAttendance;
 import kr.mashup.branding.domain.schedule.QEvent;
 import kr.mashup.branding.domain.schedule.QSchedule;
 import kr.mashup.branding.domain.schedule.Schedule;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 public class CustomAttendanceRepositoryImpl implements CustomAttendanceRepository {
@@ -20,7 +19,7 @@ public class CustomAttendanceRepositoryImpl implements CustomAttendanceRepositor
 	private final QSchedule qSchedule = QSchedule.schedule;
 	private final QEvent qEvent = QEvent.event;
 
-	public List<Attendance> getBySchedule(Schedule schedule) {
+	public List<Attendance> findBySchedule(Schedule schedule) {
 		return jpaQueryFactory
 			.select(qAttendance)
 			.from(qAttendance)

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustom.java
@@ -5,8 +5,6 @@ import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.Platform;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,6 +22,8 @@ public interface MemberRepositoryCustom {
     Page<Member> findActiveByPlatformAndGeneration(Platform platform, Generation generation, Pageable pageable);
 
     List<Member> findAllByCurrentGenerationAt(LocalDate at);
+
+    List<Member> findAllActiveByGeneration(Generation generation);
 }
 /**
  * Member 연관관계

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
@@ -147,5 +147,16 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
             )
             .fetch();
     }
+
+    @Override
+    public List<Member> findAllActiveByGeneration(Generation generation) {
+        return queryFactory
+                .selectFrom(member)
+                .innerJoin(memberGeneration)
+                .on(memberGeneration.member.eq(member)
+                        .and(memberGeneration.generation.eq(generation)))
+                .where(member.status.eq(MemberStatus.ACTIVE))
+                .fetch();
+    }
 }
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -2,16 +2,13 @@ package kr.mashup.branding.repository.schedule;
 
 import kr.mashup.branding.domain.schedule.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
 
-    @Query("SELECT s FROM Schedule s WHERE s.isCounted = :isCounted")
-    List<Schedule> findAllByIsCounted(@Param("isCounted") boolean isCounted);
+    List<Schedule> findAllByIsCounted(Boolean isCounted);
 
     Schedule findByStartedAt(LocalDateTime startedAt);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/attendance/AttendanceService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/attendance/AttendanceService.java
@@ -1,20 +1,19 @@
 package kr.mashup.branding.service.attendance;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.attendance.AttendanceStatus;
-import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.exception.NotFoundException;
 import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.repository.attendance.AttendanceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -60,7 +59,7 @@ public class AttendanceService {
     }
 
     public Map<Member, List<Attendance>> getByScheduleAndGroupByMember(Schedule schedule) {
-        return attendanceRepository.getBySchedule(schedule).stream()
+        return attendanceRepository.findBySchedule(schedule).stream()
             .collect(Collectors.groupingBy(Attendance::getMember));
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -205,4 +204,7 @@ public class MemberService {
         member.updatePushNotificationAgreed(pushNotificationAgreed);
     }
 
+    public List<Member> getActiveAllByGeneration(Generation generation) {
+        return memberRepository.findAllActiveByGeneration(generation);
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/scorehistory/ScoreHistoryService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/scorehistory/ScoreHistoryService.java
@@ -67,7 +67,7 @@ public class ScoreHistoryService {
         List<Event> events,
         List<Attendance> attendances
     ) {
-        ScoreType scoreType = null;
+        ScoreType scoreType = ScoreType.ATTENDANCE;
 
         final long attendanceNumber = attendances.stream()
             .filter(attendance -> attendance.getStatus() == AttendanceStatus.ATTENDANCE)
@@ -75,13 +75,12 @@ public class ScoreHistoryService {
         final long lateNumber = attendances.size() - attendanceNumber;
         final long absentNumber = events.size() - attendances.size();
 
-        if(attendanceNumber == events.size()){      // 출석한 개수와 이벤트 개수가 같은 경우
-            scoreType = ScoreType.ATTENDANCE;
-        } else if (absentNumber > 0) {              // 결석이 하나 이상인 경우
+        if (absentNumber > 0) {             // 결석이 하나 이상인 경우
             scoreType = ScoreType.ABSENT;
-        } else if (lateNumber > 0) {                // 지각이 하나 이상인 경우
+        } else if (lateNumber > 0) {        // 지각이 하나 이상인 경우
             scoreType = ScoreType.LATE;
         }
+
         return scoreType;
     }
 
@@ -91,5 +90,9 @@ public class ScoreHistoryService {
 
     public List<ScoreHistory> findAttendanceScoreByDate(LocalDate date) {
         return scoreHistoryRepository.retrieveAttendanceScoreByDate(date);
+    }
+
+    public List<ScoreHistory> saveAll(List<ScoreHistory> scoreHistories) {
+        return scoreHistoryRepository.saveAll(scoreHistories);
     }
 }


### PR DESCRIPTION
## PR 타입
- 기능 수정

## 개요
- 출석체크한 데이터가 경우에 결석으로 처리가 되지 않고 있습니다.

##  변경사항
- 출석점수를 계산할 스케줄의 기수값을 기준으로 멤버를 조회합니다.
- 출석체크한 데이터가 모두/부분적으로 존재하는 경우 -> 존재하는 데이터로 출석점수 계산(기존로직)
- 출석체크한 데이터가 모두 없는 경우 -> 결석으로 처리(추가된 로직)
