### PR TITLE
회원가입 시 기본점수 부여 원복

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Member.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Member.java
@@ -55,7 +55,6 @@ public class Member extends BaseEntity {
 
     private String fcmToken;
 
-    // TODO: 기본 설정값 논의
     private Boolean pushNotificationAgreed = true;
 
     public boolean isMatchPassword(String rawPassword, PasswordEncoder encoder) {
@@ -79,8 +78,10 @@ public class Member extends BaseEntity {
             String identification,
             String rawPassword,
             PasswordEncoder encoder,
-            Boolean privatePolicyAgreed) {
-        return new Member(name, identification, rawPassword, encoder, privatePolicyAgreed);
+            Boolean privatePolicyAgreed,
+            OsType osType,
+            String fcmToken) {
+        return new Member(name, identification, rawPassword, encoder, privatePolicyAgreed, osType, fcmToken);
     }
 
     private Member(
@@ -88,7 +89,9 @@ public class Member extends BaseEntity {
             String identification,
             String rawPassword,
             PasswordEncoder encoder,
-            Boolean privatePolicyAgreed) {
+            Boolean privatePolicyAgreed,
+            OsType osType,
+            String fcmToken) {
 
         checkAgreePrivacyPolicy(privatePolicyAgreed);
         checkValidName(name);
@@ -101,6 +104,8 @@ public class Member extends BaseEntity {
         this.privatePolicyAgreed = privatePolicyAgreed;
         this.status = MemberStatus.ACTIVE;
         //this.status = MemberStatus.PENDING;
+        this.osType = osType;
+        this.fcmToken = fcmToken;
     }
 
     private void checkValidID(String identification) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/dto/member/MemberCreateDto.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/dto/member/MemberCreateDto.java
@@ -1,6 +1,7 @@
 package kr.mashup.branding.dto.member;
 
 import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.member.OsType;
 import kr.mashup.branding.domain.member.Platform;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,4 +21,8 @@ public class MemberCreateDto {
     private Generation generation;
 
     private Boolean privatePolicyAgreed;
+
+    private OsType osType;
+
+    private String fcmToken;
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -45,7 +45,9 @@ public class MemberService {
             memberCreateDto.getIdentification(),
             memberCreateDto.getPassword(),
             passwordEncoder,
-            memberCreateDto.getPrivatePolicyAgreed()
+            memberCreateDto.getPrivatePolicyAgreed(),
+            memberCreateDto.getOsType(),
+            memberCreateDto.getFcmToken()
         );
         memberRepository.save(member);
 
@@ -194,14 +196,6 @@ public class MemberService {
         return memberRepository.findAllByCurrentGenerationAt(LocalDate.now()).stream()
             .filter(Member::getPushNotificationAgreed)
             .collect(Collectors.toList());
-    }
-
-    public void updatePushNotificationInfo(OsType osType, String fcmToken, Member member) {
-        member.updatePushNotificationInfo(osType, fcmToken);
-    }
-
-    public void updatePushNotificationAgreed(Boolean pushNotificationAgreed, Member member) {
-        member.updatePushNotificationAgreed(pushNotificationAgreed);
     }
 
     public List<Member> getActiveAllByGeneration(Generation generation) {

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
@@ -58,7 +58,7 @@ public class MemberFacadeService {
         Platform latestPlatform = memberService.getLatestPlatform(member);
 
         // 로그인 시점에 푸시 알림을 위한 정보 업데이트
-        memberService.updatePushNotificationInfo(request.getOsType(), request.getFcmToken(), member);
+        member.updatePushNotificationInfo(request.getOsType(), request.getFcmToken());
 
         return AccessResponse.of(member,latestPlatform,token);
     }
@@ -84,18 +84,17 @@ public class MemberFacadeService {
                 request.getPassword(),
                 platform,
                 generation,
-                request.getPrivatePolicyAgreed());
+                request.getPrivatePolicyAgreed(),
+                request.getOsType(),
+                request.getFcmToken());
 
         final Member member = memberService.save(memberCreateDto);
         final String token = jwtService.encode(member.getId());
         Platform latestPlatform = memberService.getLatestPlatform(member);
 
-        // 기본 활동 점수 부여
-        ScoreHistory scoreHistory = ScoreHistory.of(ScoreType.ATTENDANCE, member, LocalDateTime.now(), "", generation, null);
+        // 회원가입 시점에 기본 활동 점수 부여
+        ScoreHistory scoreHistory = ScoreHistory.of(ScoreType.DEFAULT, member, LocalDateTime.now(), "", generation, null);
         scoreHistoryService.save(scoreHistory);
-
-        // 회원가입 시점에 푸시 알림을 위한 정보 업데이트
-        memberService.updatePushNotificationInfo(request.getOsType(), request.getFcmToken(), member);
 
         return AccessResponse.of(member,latestPlatform, token);
     }
@@ -128,7 +127,7 @@ public class MemberFacadeService {
     @Transactional
     public Boolean updatePushNotificationAgreed(Long memberId, PushNotificationRequest request) {
         Member member = memberService.getActiveOrThrowById(memberId);
-        memberService.updatePushNotificationAgreed(request.getPushNotificationAgreed(), member);
+        member.updatePushNotificationAgreed(request.getPushNotificationAgreed());
         return true;
     }
 }


### PR DESCRIPTION
## PR 타입
- 기능 수정

## 개요
- 모바일에서 기본점수 타입이 없어서 회원가입시에 임시로 ATTENDACE로 변경하 부분 원복하였습니다.
- 회원가입 시에 멤버를 저장한 후에 fcm 관련 필드 업데이트 하는 로직에서 멤버 저장시에 같이 저장하는 방식으로 변경하였습니다.

##  변경사항

