### PR TITLE
Feature/danggn domain

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
@@ -19,11 +19,31 @@ public class DanggnScore {
     @GeneratedValue
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_generation_id")
     private MemberGeneration memberGeneration;
 
     private Long totalShakeScore;
 
     @LastModifiedDate
     protected LocalDateTime lastShakedAt;
+
+    public static DanggnScore of(
+        MemberGeneration memberGeneration,
+        Long totalShakeScore
+    ) {
+        return new DanggnScore(memberGeneration, totalShakeScore);
+    }
+
+    private DanggnScore(
+        MemberGeneration memberGeneration,
+        Long totalShakeScore
+    ) {
+        this.memberGeneration = memberGeneration;
+        this.totalShakeScore = totalShakeScore;
+    }
+
+    public void addScore(Long score) {
+        this.totalShakeScore += score;
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
@@ -1,0 +1,29 @@
+package kr.mashup.branding.domain.danggn;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DanggnScore {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToOne
+    private MemberGeneration memberGeneration;
+
+    private Long totalShakeScore;
+
+    @LastModifiedDate
+    protected LocalDateTime lastShakedAt;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnShakeLog.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnShakeLog.java
@@ -1,0 +1,29 @@
+package kr.mashup.branding.domain.danggn;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DanggnShakeLog {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToOne
+    private MemberGeneration memberGeneration;
+
+    private Long shakeScore;
+
+    @CreatedDate
+    protected LocalDateTime createdAt;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnShakeLog.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnShakeLog.java
@@ -26,4 +26,19 @@ public class DanggnShakeLog {
 
     @CreatedDate
     protected LocalDateTime createdAt;
+
+    public static DanggnShakeLog of(
+        MemberGeneration memberGeneration,
+        Long shakeScore
+    ) {
+        return new DanggnShakeLog(memberGeneration, shakeScore);
+    }
+
+    private DanggnShakeLog(
+        MemberGeneration memberGeneration,
+        Long shakeScore
+    ) {
+        this.memberGeneration = memberGeneration;
+        this.shakeScore = shakeScore;
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
@@ -23,7 +23,7 @@ public class MemberGeneration extends BaseEntity {
     @JoinColumn(name = "generation_id")
     private Generation generation;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "memberGeneration", orphanRemoval = true)
+    @OneToOne(cascade= CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "memberGeneration", orphanRemoval = true)
     private DanggnScore danggnScore;
 
     @Enumerated(EnumType.STRING)

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
@@ -1,18 +1,14 @@
 package kr.mashup.branding.domain.member;
 
 import kr.mashup.branding.domain.BaseEntity;
+import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.generation.Generation;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -26,6 +22,9 @@ public class MemberGeneration extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "generation_id")
     private Generation generation;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "memberGeneration", orphanRemoval = true)
+    private DanggnScore danggnScore;
 
     @Enumerated(EnumType.STRING)
     private Platform platform;
@@ -43,5 +42,10 @@ public class MemberGeneration extends BaseEntity {
         this.platform = platform;
     }
 
-
+    public DanggnScore getDanggnScore() {
+        if (danggnScore == null) {
+            this.danggnScore = DanggnScore.of(this, 0L);
+        }
+        return this.danggnScore;
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepository.java
@@ -1,0 +1,7 @@
+package kr.mashup.branding.repository.danggn;
+
+import kr.mashup.branding.domain.danggn.DanggnScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DanggnScoreRepository extends JpaRepository<DanggnScore, Long> {
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnShakeLogRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnShakeLogRepository.java
@@ -1,0 +1,7 @@
+package kr.mashup.branding.repository.danggn;
+
+import kr.mashup.branding.domain.danggn.DanggnShakeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DanggnShakeLogRepository extends JpaRepository<DanggnShakeLog, Long> {
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface MemberGenerationRepository extends JpaRepository<MemberGeneration, Long> {
+public interface MemberGenerationRepository extends JpaRepository<MemberGeneration, Long>, MemberGenerationRepositoryCustom {
 
     void deleteByMember(Member member);
     Optional<MemberGeneration> findByMemberAndGeneration(Member member, Generation generation);

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package kr.mashup.branding.repository.member;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+
+import java.util.Optional;
+
+public interface MemberGenerationRepositoryCustom {
+    Optional<MemberGeneration> findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
@@ -1,0 +1,19 @@
+package kr.mashup.branding.repository.member;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class MemberGenerationRepositoryCustomImpl implements MemberGenerationRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberGeneration> findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber) {
+        // ToDo implement below
+        return Optional.empty();
+    }
+}
+

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
@@ -6,14 +6,21 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
 
+import static kr.mashup.branding.domain.generation.QGeneration.generation;
+import static kr.mashup.branding.domain.member.QMemberGeneration.memberGeneration;
+
 @RequiredArgsConstructor
 public class MemberGenerationRepositoryCustomImpl implements MemberGenerationRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
     public Optional<MemberGeneration> findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber) {
-        // ToDo implement below
-        return Optional.empty();
+        return Optional.ofNullable(queryFactory
+            .selectFrom(memberGeneration)
+            .join(memberGeneration.generation, generation)
+            .where(memberGeneration.member.id.eq(memberId), generation.number.eq(generationNumber))
+            .fetchOne()
+        );
     }
 }
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnScoreService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnScoreService.java
@@ -1,0 +1,11 @@
+package kr.mashup.branding.service.danggn;
+
+import kr.mashup.branding.repository.danggn.DanggnScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnScoreService {
+    private final DanggnScoreRepository danggnScoreRepository;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnShakeLogService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnShakeLogService.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.service.danggn;
+
+import kr.mashup.branding.domain.danggn.DanggnShakeLog;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.repository.danggn.DanggnShakeLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnShakeLogService {
+    private final DanggnShakeLogRepository danggnShakeLogRepository;
+
+    @Transactional
+    public DanggnShakeLog createLog(MemberGeneration memberGeneration, Long score) {
+        return danggnShakeLogRepository.save(
+            DanggnShakeLog.of(memberGeneration, score)
+        );
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.service.member;
 
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
+import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.member.*;
 import kr.mashup.branding.domain.member.exception.MemberLoginFailException;
@@ -200,5 +201,10 @@ public class MemberService {
 
     public List<Member> getActiveAllByGeneration(Generation generation) {
         return memberRepository.findAllActiveByGeneration(generation);
+    }
+
+    public MemberGeneration findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber) {
+        return memberGenerationRepository.findByMemberIdAndGenerationNumber(memberId, generationNumber)
+                .orElseThrow(GenerationIntegrityFailException::new);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -2,6 +2,7 @@ package kr.mashup.branding.facade.danggn;
 
 import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.service.danggn.DanggnShakeLogService;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,9 @@ import javax.transaction.Transactional;
 public class DanggnFacadeService {
     private final MemberService memberService;
 
+    private final DanggnShakeLogService danggnShakeLogService;
+
+
     @Transactional
     public DanggnScoreResponse addScore(
         Long memberId,
@@ -23,6 +27,7 @@ public class DanggnFacadeService {
         final MemberGeneration memberGeneration = memberService.findByMemberIdAndGenerationNumber(memberId, generationNumber);
         final DanggnScore danggnScore = memberGeneration.getDanggnScore();
         danggnScore.addScore(score);
+        danggnShakeLogService.createLog(memberGeneration, score);
         return DanggnScoreResponse.of(memberGeneration);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -1,0 +1,28 @@
+package kr.mashup.branding.facade.danggn;
+
+import kr.mashup.branding.domain.danggn.DanggnScore;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnFacadeService {
+    private final MemberService memberService;
+
+    @Transactional
+    public DanggnScoreResponse addScore(
+        Long memberId,
+        Integer generationNumber,
+        Long score
+    ) {
+        final MemberGeneration memberGeneration = memberService.findByMemberIdAndGenerationNumber(memberId, generationNumber);
+        final DanggnScore danggnScore = memberGeneration.getDanggnScore();
+        danggnScore.addScore(score);
+        return DanggnScoreResponse.of(memberGeneration);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
@@ -1,0 +1,38 @@
+package kr.mashup.branding.ui.danggn;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.danggn.DanggnFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.danggn.request.DanggnScoreAddRequest;
+import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RestController
+@RequestMapping("api/v1/danggn")
+@RequiredArgsConstructor
+public class DanggnController {
+    private final DanggnFacadeService danggnFacadeService;
+
+    @ApiOperation(
+        value = "당근 흔들기 점수 추가",
+        notes =
+            "<h2>Error Code</h2>" +
+                "<p>" +
+                "MEMBER_NOT_FOUND</br>" +
+                "MEMBER_GENERATION_NOT_FOUND</br>" +
+                "</p>"
+
+    )
+    @PostMapping("/score")
+    public ApiResponse<DanggnScoreResponse> addDanggnScore(
+        @ApiIgnore MemberAuth auth,
+        @RequestBody DanggnScoreAddRequest req,
+        @RequestParam(defaultValue = "13", required = false) Integer generationNumber
+    ) {
+        DanggnScoreResponse response = danggnFacadeService.addScore(auth.getMemberId(), generationNumber, req.getScore());
+        return ApiResponse.success(response);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/request/DanggnScoreAddRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/request/DanggnScoreAddRequest.java
@@ -1,0 +1,8 @@
+package kr.mashup.branding.ui.danggn.request;
+
+import lombok.Getter;
+
+@Getter
+public class DanggnScoreAddRequest {
+    private Long score;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnScoreResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnScoreResponse.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.ui.danggn.response;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.Getter;
+import lombok.Value;
+
+@Getter
+@Value(staticConstructor = "of")
+public class DanggnScoreResponse {
+    Long memberId;
+
+    Long totalShakeScore;
+
+    public static DanggnScoreResponse of(
+        MemberGeneration memberGeneration
+    ) {
+        return new DanggnScoreResponse(
+            memberGeneration.getMember().getId(),
+            memberGeneration.getDanggnScore().getTotalShakeScore()
+        );
+    }
+}


### PR DESCRIPTION
## PR 타입

## 개요

##  변경사항
- danggnscore, danggnshakelog 도메인 정의
- 당근 흔들때 add score api 추가
    - memberid, generation num으로 한번에 membergeneration 가져오는 querydsl 추가
    - danggnscore에 점수 추가 후 로깅까지 수행

테스트완
