### PR TITLE
당근 푸시 알림 필드 추가

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Member.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Member.java
@@ -55,7 +55,9 @@ public class Member extends BaseEntity {
 
     private String fcmToken;
 
-    private Boolean pushNotificationAgreed = true;
+    private Boolean newsPushNotificationAgreed = true;          // 매시업 소식 알림 동의 여부
+
+    private Boolean danggnPushNotificationAgreed = true;        // 당근 흔들기 알림 동의 여부
 
     public boolean isMatchPassword(String rawPassword, PasswordEncoder encoder) {
         return encoder.matches(rawPassword, this.password);
@@ -145,7 +147,8 @@ public class Member extends BaseEntity {
         this.fcmToken = fcmToken;
     }
 
-    public void updatePushNotificationAgreed(Boolean pushNotificationAgreed) {
-        this.pushNotificationAgreed = pushNotificationAgreed;
+    public void updatePushNotificationAgreed(Boolean newsPushNotificationAgreed, Boolean danggnPushNotificationAgreed) {
+        this.newsPushNotificationAgreed = newsPushNotificationAgreed;
+        this.danggnPushNotificationAgreed = danggnPushNotificationAgreed;
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/FcmPushNotiService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/FcmPushNotiService.java
@@ -36,7 +36,7 @@ public class FcmPushNotiService implements PushNotiService {
 
     private List<String> getAgreedFcmTokens(List<Member> members) {
         return members.stream()
-            .filter(Member::getPushNotificationAgreed)
+            .filter(Member::getNewsPushNotificationAgreed)
             .map(Member::getFcmToken)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -195,7 +195,7 @@ public class MemberService {
 
     public List<Member> getAllPushNotiTargetableMembers() {
         return memberRepository.findAllByCurrentGenerationAt(LocalDate.now()).stream()
-            .filter(Member::getPushNotificationAgreed)
+            .filter(Member::getNewsPushNotificationAgreed)
             .collect(Collectors.toList());
     }
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
@@ -127,7 +127,10 @@ public class MemberFacadeService {
     @Transactional
     public Boolean updatePushNotificationAgreed(Long memberId, PushNotificationRequest request) {
         Member member = memberService.getActiveOrThrowById(memberId);
-        member.updatePushNotificationAgreed(request.getPushNotificationAgreed());
+        member.updatePushNotificationAgreed(
+                request.getNewsPushNotificationAgreed(),
+                request.getDanggnPushNotificationAgreed()
+        );
         return true;
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/PushNotificationRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/PushNotificationRequest.java
@@ -10,6 +10,6 @@ public class PushNotificationRequest {
     @NotNull(message = "매시업 소식 알림 동의 여부는 필수값입니다.")
     private Boolean newsPushNotificationAgreed;
 
-    @NotNull(message = "당근ㄴ 흔들기 알림 동의 여부는 필수값입니다.")
+    @NotNull(message = "당근 흔들기 알림 동의 여부는 필수값입니다.")
     private Boolean danggnPushNotificationAgreed;
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/PushNotificationRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/PushNotificationRequest.java
@@ -7,6 +7,9 @@ import javax.validation.constraints.NotNull;
 @Getter
 public class PushNotificationRequest {
 
-    @NotNull(message = "푸시 알림 동의 여부는 필수값입니다.")
-    private Boolean pushNotificationAgreed;
+    @NotNull(message = "매시업 소식 알림 동의 여부는 필수값입니다.")
+    private Boolean newsPushNotificationAgreed;
+
+    @NotNull(message = "당근ㄴ 흔들기 알림 동의 여부는 필수값입니다.")
+    private Boolean danggnPushNotificationAgreed;
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/AccessResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/AccessResponse.java
@@ -25,7 +25,9 @@ public class AccessResponse {
     // 정렬 ASC
     private List<Integer> generations;
 
-    private Boolean pushNotificationAgreed;
+    private Boolean newsPushNotificationAgreed;
+
+    private Boolean danggnPushNotificationAgreed;
 
     public static AccessResponse of(Member member, Platform platform, String token) {
         return new AccessResponse(
@@ -38,7 +40,8 @@ public class AccessResponse {
                         .map(it-> it.getGeneration().getNumber())
                         .sorted()
                         .collect(Collectors.toList()),
-                member.getPushNotificationAgreed());
+                member.getNewsPushNotificationAgreed(),
+                member.getDanggnPushNotificationAgreed());
     }
 
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberInfoResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberInfoResponse.java
@@ -22,7 +22,9 @@ public class MemberInfoResponse {
 
     private List<Integer> generations;
 
-    private Boolean pushNotificationAgreed;
+    private Boolean newsPushNotificationAgreed;
+
+    private Boolean danggnPushNotificationAgreed;
 
     public static MemberInfoResponse from(Member member, Platform platform) {
         return MemberInfoResponse.of(
@@ -34,8 +36,8 @@ public class MemberInfoResponse {
                         .stream()
                         .map(it -> it.getGeneration().getNumber())
                         .collect(Collectors.toList()),
-                member.getPushNotificationAgreed()
+                member.getNewsPushNotificationAgreed(),
+                member.getDanggnPushNotificationAgreed()
         );
     }
-
 }


### PR DESCRIPTION
## PR 타입
- 기능

## 개요
- 당근 푸시 알림 필드가 추가합니다.

##  변경사항

AS-IS

```java
private Boolean pushNotificationAgreed = true;
```

TO-BE

```java
private Boolean newsPushNotificationAgreed = true;        // 매시업 소식 알림 동의 여부

private Boolean danggnPushNotificationAgreed = true;   // 당근 푸시 알림 동의 여부
```