### PR TITLE
feat: 당근 랭킹 1위 업데이트 알림을 위한 캐시 구현

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/config/LocalCacheConfig.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/config/LocalCacheConfig.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@EnableCaching
+public class LocalCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        simpleCacheManager.setCaches(List.of(new ConcurrentMapCache("danggnFirstPlaceRecord")));
+        return simpleCacheManager;
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/DanggnFirstRecordMemberUpdatedVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/DanggnFirstRecordMemberUpdatedVo.java
@@ -1,0 +1,14 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import kr.mashup.branding.domain.member.Member;
+
+import java.util.List;
+
+public class DanggnFirstRecordMemberUpdatedVo extends PushNotiSendVo {
+    private static final String title = "당근 흔들기 개인 랭킹 1위가 업데이트 됐어요";
+    private static final String body = "과연 누가 1위를 탈환했을까요?";
+
+    public DanggnFirstRecordMemberUpdatedVo(List<Member> members) {
+        super(members, title, body);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/DanggnFirstRecordPlatformUpdatedVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/DanggnFirstRecordPlatformUpdatedVo.java
@@ -1,0 +1,14 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import kr.mashup.branding.domain.member.Member;
+
+import java.util.List;
+
+public class DanggnFirstRecordPlatformUpdatedVo extends PushNotiSendVo {
+    private static final String title = "당근 흔들기 팀 랭킹 1위가 업데이트 됏어요";
+    private static final String body = "과연 누가 1위를 탈환했을까요?";
+
+    public DanggnFirstRecordPlatformUpdatedVo(List<Member> members) {
+        super(members, title, body);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheKey.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheKey.java
@@ -1,0 +1,7 @@
+package kr.mashup.branding.service.danggn;
+
+public enum DanggnCacheKey {
+    MEMBER,     // 멤버
+    PLATFORM    // 플랫폼
+    ;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
@@ -16,14 +16,14 @@ import static kr.mashup.branding.repository.danggn.DanggnScoreRepositoryCustomIm
 public class DanggnCacheService {
     private final DanggnScoreRepository danggnScoreRepository;
 
-    @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "#key + #generationNumber.toString()")
-    public String getCachedFirstRecord(DanggnCacheKey key, Integer generationNumber) {
-        if (DanggnCacheKey.MEMBER.equals(key)) {
-            return findFirstRecordMemberId(generationNumber);
-        } else if (DanggnCacheKey.PLATFORM.equals(key)) {
-            return findFirstRecordPlatform(generationNumber);
-        }
-        return null;
+    @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "T(kr.mashup.branding.service.danggn.DanggnCacheKey).MEMBER + #generationNumber.toString()")
+    public String getCachedFirstRecordMemberId(Integer generationNumber) {
+        return findFirstRecordMemberId(generationNumber);
+    }
+
+    @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "T(kr.mashup.branding.service.danggn.DanggnCacheKey).PLATFORM + #generationNumber.toString()")
+    public String getCachedFirstRecordPlatform(Integer generationNumber) {
+        return findFirstRecordPlatform(generationNumber);
     }
 
     @CachePut(cacheNames = "danggnFirstPlaceRecord", key = "#key + #generationNumber.toString()")

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
@@ -1,0 +1,57 @@
+package kr.mashup.branding.service.danggn;
+
+import kr.mashup.branding.domain.danggn.DanggnScore;
+import kr.mashup.branding.repository.danggn.DanggnScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static kr.mashup.branding.repository.danggn.DanggnScoreRepositoryCustomImpl.DanggnScorePlatformQueryResult;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnCacheService {
+    private final DanggnScoreRepository danggnScoreRepository;
+
+    @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "#key + #generationNumber.toString()")
+    public String getCachedFirstRecord(DanggnCacheKey key, Integer generationNumber) {
+        if (DanggnCacheKey.MEMBER.equals(key)) {
+            return findFirstRecordMemberId(generationNumber);
+        } else if (DanggnCacheKey.PLATFORM.equals(key)) {
+            return findFirstRecordPlatform(generationNumber);
+        }
+        return null;
+    }
+
+    @CachePut(cacheNames = "danggnFirstPlaceRecord", key = "#key + #generationNumber.toString()")
+    public String updateCachedFirstRecord(DanggnCacheKey key, Integer generationNumber, String value) {
+        return value;
+    }
+
+    public String findFirstRecordMemberId(Integer generationNumber) {
+        List<DanggnScore> danggnScores = danggnScoreRepository.findOrderedListByGenerationNum(generationNumber);
+
+        if (danggnScores.isEmpty()) {
+            return null;
+        }
+        return danggnScores.get(0)
+                .getMemberGeneration()
+                .getMember()
+                .getId()
+                .toString();
+    }
+
+    public String findFirstRecordPlatform(Integer generationNumber) {
+        List<DanggnScorePlatformQueryResult> results = danggnScoreRepository.findOrderedDanggnScorePlatformListByGenerationNum(generationNumber);
+
+        if (results.isEmpty()) {
+            return null;
+        }
+        return results.get(0)
+                .getPlatform()
+                .toString();
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
@@ -9,13 +9,16 @@ import kr.mashup.branding.repository.generation.GenerationRepository;
 import kr.mashup.branding.service.generation.vo.GenerationCreateVo;
 import kr.mashup.branding.service.generation.vo.GenerationUpdateVo;
 import kr.mashup.branding.util.DateRange;
+import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -72,5 +75,12 @@ public class GenerationService {
         generation.changeDate(generationDateRange);
 
         return generation;
+    }
+
+    public List<Generation> getAllActiveInAt(LocalDate at) {
+        return generationRepository.findAll()
+                .stream()
+                .filter(generation -> DateUtil.isInTime(generation.getStartedAt(), generation.getEndedAt(), at))
+                .collect(Collectors.toList());
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -207,4 +207,10 @@ public class MemberService {
         return memberGenerationRepository.findByMemberIdAndGenerationNumber(memberId, generationNumber)
                 .orElseThrow(GenerationIntegrityFailException::new);
     }
+
+    public List<Member> getAllDanggnPushNotiTargetableMembers() {
+        return memberRepository.findAllByCurrentGenerationAt(LocalDate.now()).stream()
+                .filter(Member::getDanggnPushNotificationAgreed)
+                .collect(Collectors.toList());
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/util/DateUtil.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/util/DateUtil.java
@@ -26,6 +26,13 @@ public class DateUtil {
         return !(target.isBefore(start) || target.isAfter(end));
     }
 
+    public static boolean isInTime(
+            LocalDate start,
+            LocalDate end,
+            LocalDate target) {
+        return !(target.isBefore(start) || target.isAfter(end));
+    }
+
     public static boolean isContainDateRange(
         DateRange baseRange,
         DateRange targetRange

--- a/mashup-member/build.gradle
+++ b/mashup-member/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation "com.amazonaws:aws-java-sdk-s3:1.12.281"
     implementation "ca.pjer:logback-awslogs-appender:1.4.0"
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     // util
     compileOnly 'org.projectlombok:lombok'

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -81,7 +81,7 @@ public class DanggnFacadeService {
         return goldenDanggnPercent;
     }
 
-    @Scheduled(fixedDelay = 60000, initialDelay = 0)
+    @Scheduled(cron = "0 0 09,13,19 * * *")
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordMemberUpdatedPushNoti() {
         // 현재 활동하는 기수 조회
@@ -95,7 +95,7 @@ public class DanggnFacadeService {
                     String currentFirstRecordMemberId = danggnCacheService.findFirstRecordMemberId(generationNumber);
                     String cachedFirstRecordMemberId = danggnCacheService.getCachedFirstRecordMemberId(generationNumber);
 
-                    if (currentFirstRecordMemberId == null || cachedFirstRecordMemberId.equals(currentFirstRecordMemberId)) {
+                    if (currentFirstRecordMemberId == null || currentFirstRecordMemberId.equals(cachedFirstRecordMemberId)) {
                         return;
                     }
                     // 변경된 부분 있으면 업데이트 푸시 알림 보낸 후 캐시 업데이트
@@ -105,7 +105,7 @@ public class DanggnFacadeService {
         );
     }
 
-    @Scheduled(fixedDelay = 60000, initialDelay = 0)
+    @Scheduled(cron = "0 0 09,13,19 * * *")
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordPlatformPushNoti() {
         // 현재 활동하는 기수 조회
@@ -119,7 +119,7 @@ public class DanggnFacadeService {
                     String currentFirstRecordPlatform = danggnCacheService.findFirstRecordPlatform(generationNumber);
                     String cachedFirstRecordPlatform = danggnCacheService.getCachedFirstRecordPlatform(generationNumber);
 
-                    if (currentFirstRecordPlatform == null || cachedFirstRecordPlatform.equals(currentFirstRecordPlatform)) {
+                    if (currentFirstRecordPlatform == null || currentFirstRecordPlatform.equals(cachedFirstRecordPlatform)) {
                         return;
                     }
                     // 변경된 부분 있으면  업데이트 푸시 알림 보낸 후 캐시 업데이트

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -93,7 +93,7 @@ public class DanggnFacadeService {
                 generation -> {
                     Integer generationNumber = generation.getNumber();
                     String currentFirstRecordMemberId = danggnCacheService.findFirstRecordMemberId(generationNumber);
-                    String cachedFirstRecordMemberId = danggnCacheService.getCachedFirstRecord(DanggnCacheKey.MEMBER, generationNumber);
+                    String cachedFirstRecordMemberId = danggnCacheService.getCachedFirstRecordMemberId(generationNumber);
 
                     if (currentFirstRecordMemberId == null || cachedFirstRecordMemberId.equals(currentFirstRecordMemberId)) {
                         return;
@@ -117,7 +117,7 @@ public class DanggnFacadeService {
                 generation -> {
                     Integer generationNumber = generation.getNumber();
                     String currentFirstRecordPlatform = danggnCacheService.findFirstRecordPlatform(generationNumber);
-                    String cachedFirstRecordPlatform = danggnCacheService.getCachedFirstRecord(DanggnCacheKey.PLATFORM, generationNumber);
+                    String cachedFirstRecordPlatform = danggnCacheService.getCachedFirstRecordPlatform(generationNumber);
 
                     if (currentFirstRecordPlatform == null || cachedFirstRecordPlatform.equals(currentFirstRecordPlatform)) {
                         return;

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -4,6 +4,9 @@ import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.domain.pushnoti.vo.DanggnFirstRecordMemberUpdatedVo;
+import kr.mashup.branding.domain.pushnoti.vo.DanggnFirstRecordPlatformUpdatedVo;
+import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
 import kr.mashup.branding.service.danggn.DanggnCacheKey;
 import kr.mashup.branding.service.danggn.DanggnCacheService;
 import kr.mashup.branding.service.danggn.DanggnScoreService;
@@ -39,6 +42,8 @@ public class DanggnFacadeService {
     private final DanggnCacheService danggnCacheService;
 
     private final GenerationService generationService;
+
+    private final PushNotiEventPublisher pushNotiEventPublisher;
 
     @Transactional
     public DanggnScoreResponse addScore(
@@ -77,7 +82,7 @@ public class DanggnFacadeService {
 
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
-    public void sendFirstRecordMemberPushNoti() {
+    public void sendDanggnFirstRecordMemberUpdatedPushNoti() {
         List<Generation> generations = generationService.getAll();
         if (generations.isEmpty())
             return;
@@ -92,7 +97,7 @@ public class DanggnFacadeService {
                         return;
                     }
                     // 변경된 부분 있으면 개인 랭킹 1 업데이트 푸시 알림 보낸 후 캐시 업데이트
-                    // TODO: 푸시 알림 로직 ex) 당근 흔들기 개인 랭킹 1위가 업데이트 됐어요
+                    pushNotiEventPublisher.publishPushNotiSendEvent(new DanggnFirstRecordMemberUpdatedVo(memberService.getAllDanggnPushNotiTargetableMembers()));
                     danggnCacheService.updateCachedFirstRecord(DanggnCacheKey.MEMBER, generationNumber, currentFirstRecordMemberId);
                 }
         );
@@ -100,7 +105,7 @@ public class DanggnFacadeService {
 
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
-    public void sendFirstRecordPlatformPushNoti() {
+    public void sendDanggnFirstRecordPlatformPushNoti() {
         List<Generation> generations = generationService.getAll();
         if (generations.isEmpty())
             return;
@@ -115,7 +120,7 @@ public class DanggnFacadeService {
                         return;
                     }
                     // 변경된 부분 있으면 개인 팀 1 업데이트 푸시 알림 보낸 후 캐시 업데이트
-                    // TODO: 푸시 알림 로직 ex) 당근 흔들기 팀 랭킹 1위가 업데이트 됏어요
+                    pushNotiEventPublisher.publishPushNotiSendEvent(new DanggnFirstRecordPlatformUpdatedVo(memberService.getAllDanggnPushNotiTargetableMembers()));
                     danggnCacheService.updateCachedFirstRecord(DanggnCacheKey.PLATFORM, generationNumber, currentFirstRecordPlatform);
                 }
         );

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -22,6 +22,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -83,7 +84,7 @@ public class DanggnFacadeService {
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordMemberUpdatedPushNoti() {
-        List<Generation> generations = generationService.getAll();
+        List<Generation> generations = generationService.getAllActiveInAt(LocalDate.now());
         if (generations.isEmpty())
             return;
 
@@ -106,7 +107,7 @@ public class DanggnFacadeService {
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordPlatformPushNoti() {
-        List<Generation> generations = generationService.getAll();
+        List<Generation> generations = generationService.getAllActiveInAt(LocalDate.now());
         if (generations.isEmpty())
             return;
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -84,6 +84,7 @@ public class DanggnFacadeService {
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordMemberUpdatedPushNoti() {
+        // 현재 활동하는 기수 조회
         List<Generation> generations = generationService.getAllActiveInAt(LocalDate.now());
         if (generations.isEmpty())
             return;
@@ -97,7 +98,7 @@ public class DanggnFacadeService {
                     if (currentFirstRecordMemberId == null || cachedFirstRecordMemberId.equals(currentFirstRecordMemberId)) {
                         return;
                     }
-                    // 변경된 부분 있으면 개인 랭킹 1 업데이트 푸시 알림 보낸 후 캐시 업데이트
+                    // 변경된 부분 있으면 업데이트 푸시 알림 보낸 후 캐시 업데이트
                     pushNotiEventPublisher.publishPushNotiSendEvent(new DanggnFirstRecordMemberUpdatedVo(memberService.getAllDanggnPushNotiTargetableMembers()));
                     danggnCacheService.updateCachedFirstRecord(DanggnCacheKey.MEMBER, generationNumber, currentFirstRecordMemberId);
                 }
@@ -107,6 +108,7 @@ public class DanggnFacadeService {
     @Scheduled(fixedDelay = 60000, initialDelay = 0)
     @Transactional(readOnly = true)
     public void sendDanggnFirstRecordPlatformPushNoti() {
+        // 현재 활동하는 기수 조회
         List<Generation> generations = generationService.getAllActiveInAt(LocalDate.now());
         if (generations.isEmpty())
             return;
@@ -120,7 +122,7 @@ public class DanggnFacadeService {
                     if (currentFirstRecordPlatform == null || cachedFirstRecordPlatform.equals(currentFirstRecordPlatform)) {
                         return;
                     }
-                    // 변경된 부분 있으면 개인 팀 1 업데이트 푸시 알림 보낸 후 캐시 업데이트
+                    // 변경된 부분 있으면  업데이트 푸시 알림 보낸 후 캐시 업데이트
                     pushNotiEventPublisher.publishPushNotiSendEvent(new DanggnFirstRecordPlatformUpdatedVo(memberService.getAllDanggnPushNotiTargetableMembers()));
                     danggnCacheService.updateCachedFirstRecord(DanggnCacheKey.PLATFORM, generationNumber, currentFirstRecordPlatform);
                 }


### PR DESCRIPTION
## PR 타입
- 기능

## 개요
- 당근 랭킹 1위 업데이트 알림 구현합니다.
- 9시, 13시, 19시에 1등 업데이트 알림
  - fyi; [회의록](https://www.notion.so/TF-11134e042443449b9d38dece8c191353?p=c0abd2ec4d5545a8b936dbf4f6596f91&pm=s)
- 현재 활동하고 있는 기수에게만 알림

##  변경사항
- 당근 랭킹 1위 업데이트
  - 현재 기준으로 활동하는 generation 조회(예외적인 케이스 제외하고 조회된 기수 1개)
  - 각 generation 돌면서, 1등이 변경된 경우
    - 랭킹 1 업데이트 푸시 알림 발송
    - 캐시 업데이트
- 1등 변경조건
  - 해당 Generation에 멤버가 1명이상 존재
  - 캐시된 데이터가 존재하고, 캐시된 데이터와 최근 데이터가 다른 경우