### PR TITLE
fix: 완료된 스케줄만 점수 계산 배치가 실행되도록 수정

### DIFF
--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -32,7 +32,7 @@ public class ScoreHistoryFacadeService {
      */
     @Transactional
     public List<Member> create() {
-        List<Schedule> schedules = scheduleService.findAllByIsCounted(false);
+        List<Schedule> schedules = scheduleService.findEndedScheduleByIsCounted(false);
         Set<Member> updatedMember = new HashSet<>();
 
         schedules.forEach(schedule -> {

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -5,12 +5,13 @@ import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
 
-    List<Schedule> findAllByIsCounted(Boolean isCounted);
+    List<Schedule> findAllByIsCountedAndEndedAtIsBefore(Boolean isCounted, LocalDateTime at);
 
     Optional<Schedule> findByIdAndStatus(Long id, ScheduleStatus status);
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -130,8 +130,8 @@ public class ScheduleService {
     }
 
 
-    public List<Schedule> findAllByIsCounted(boolean isCounted) {
-        return scheduleRepository.findAllByIsCounted(isCounted);
+    public List<Schedule> findEndedScheduleByIsCounted(boolean isCounted) {
+        return scheduleRepository.findAllByIsCountedAndEndedAtIsBefore(isCounted, LocalDateTime.now());
     }
 
     public Schedule findByStartDate(LocalDate startDate) {


### PR DESCRIPTION
## PR 타입
- 버그
## 개요
- 완료된 스케줄만 점수 계산 배치가 실행되도록 수정합니다.
- 푸시 알림 필드가 real 에 반영이 안 되어있어서, 핫픽스건만 체리픽으로 먼저 나갈게용!

##  변경사항
- 현재 날짜 기준으로 Schedule.EndedAt 이 더 과거인 조건 추가(완료된 스케줄)