### PR TITLE
Feature/member popup

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
@@ -79,6 +79,7 @@ public enum ResultCode {
     GENERATION_NOT_FOUND("기수가 존재하지 않습니다."),
     GENERATION_ALREADY_EXISTS("이미 존재하는 기수입니다."),
     MEMBER_GENERATION_NOT_FOUND("사용자의 기수 정보가 존재하지 않습니다."),
+    INACTIVE_GENERATION("활동하지 않느 기수입니다."),
 
     // AttendanceCode (출석 코드)
     ATTENDANCE_CODE_DUPLICATED("이미 사용된 코드입니다."),
@@ -106,7 +107,11 @@ public enum ResultCode {
 
     // JsonUtil
     JSON_DESERIALIZE_UNABLE("객체를 json string 을 deserialize 할 수 없습니다"),
-    JSON_SERIALIZE_UNABLE("json string 을 객체로 serialize 할 수 없습니다");
+    JSON_SERIALIZE_UNABLE("json string 을 객체로 serialize 할 수 없습니다"),
+
+    // Member Popup
+    MEMBER_POPUP_NOT_FOUND("팝업을 찾을 수 없습니다."),
+    ;
 
 
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/exception/InactiveGenerationException.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/exception/InactiveGenerationException.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.domain.member.exception;
+
+import kr.mashup.branding.domain.ResultCode;
+import kr.mashup.branding.domain.exception.NotFoundException;
+
+public class InactiveGenerationException extends NotFoundException {
+	public InactiveGenerationException() {
+		super(ResultCode.INACTIVE_GENERATION);
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/MemberPopup.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/MemberPopup.java
@@ -1,0 +1,62 @@
+package kr.mashup.branding.domain.popup;
+
+import java.time.LocalDate;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import kr.mashup.branding.domain.BaseEntity;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.storage.Storage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberPopup extends BaseEntity {
+
+	private Boolean hasVisited;		// 페이지 접근 여부
+
+	private LocalDate lastViewedAt;	// 팝업 마지막으로 본 날짜
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "storage_id")
+	private Storage storage;
+
+	public static MemberPopup of(
+		Boolean isVisible,
+		LocalDate lastViewedAt,
+		Member member,
+		Storage storage
+	) {
+		return new MemberPopup(isVisible, lastViewedAt, member, storage);
+	}
+
+	private MemberPopup(
+		Boolean hasVisited,
+		LocalDate lastViewedAt,
+		Member member,
+		Storage storage
+	) {
+		this.hasVisited = hasVisited;
+		this.lastViewedAt = lastViewedAt;
+		this.member = member;
+		this.storage = storage;
+	}
+
+	public void updateHasVisited(Boolean isVisible) {
+		this.hasVisited = isVisible;
+	}
+
+	public void updateLastViewedAt(LocalDate at) {
+		this.lastViewedAt = at;
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/exception/MemberPopupNotFoundException.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/exception/MemberPopupNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.mashup.branding.domain.popup.exception;
+
+import kr.mashup.branding.domain.ResultCode;
+import kr.mashup.branding.domain.exception.NotFoundException;
+
+public class MemberPopupNotFoundException extends NotFoundException {
+
+    public MemberPopupNotFoundException() {
+        super(ResultCode.MEMBER_POPUP_NOT_FOUND);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/memberpopup/MemberPopupRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/memberpopup/MemberPopupRepository.java
@@ -1,0 +1,14 @@
+package kr.mashup.branding.repository.memberpopup;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.popup.MemberPopup;
+import kr.mashup.branding.domain.storage.Storage;
+
+public interface MemberPopupRepository extends JpaRepository<MemberPopup, Long> {
+
+	Optional<MemberPopup> findByMemberAndStorage(Member member, Storage storage);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -1,5 +1,16 @@
 package kr.mashup.branding.service.member;
 
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
@@ -15,17 +26,8 @@ import kr.mashup.branding.dto.member.MemberCreateDto;
 import kr.mashup.branding.repository.member.MemberGenerationRepository;
 import kr.mashup.branding.repository.member.MemberRepository;
 import kr.mashup.branding.repository.member.MemberRepositoryCustomImpl.MemberScoreQueryResult;
+import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -219,5 +221,10 @@ public class MemberService {
 
     public MemberGeneration findByMemberGenerationId(Long memberGenerationId) {
         return memberGenerationRepository.findById(memberGenerationId).orElseThrow(GenerationIntegrityFailException::new);
+    }
+
+    public Boolean isActiveGeneration(MemberGeneration memberGeneration) {
+        Generation generation = memberGeneration.getGeneration();
+        return DateUtil.isInTime(generation.getStartedAt(), generation.getEndedAt(), LocalDate.now());
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/memberpopup/MemberPopupService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/memberpopup/MemberPopupService.java
@@ -1,0 +1,34 @@
+package kr.mashup.branding.service.memberpopup;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.popup.MemberPopup;
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.repository.memberpopup.MemberPopupRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberPopupService {
+
+	private final MemberPopupRepository memberPopupRepository;
+
+	public MemberPopup findOrSaveMemberPopupByMemberAndStorage(Member member, Storage storage) {
+		return memberPopupRepository.findByMemberAndStorage(member, storage)
+			.orElseGet(() -> memberPopupRepository.save(MemberPopup.of(false, LocalDate.now(), member, storage)));
+	}
+
+	public Boolean isPossibleMemberPopup(Member member, Storage storage) {
+		Optional<MemberPopup> memberPopup = memberPopupRepository.findByMemberAndStorage(member, storage);
+		// 팝업 또는 페이지에 방문하지 않은 경우
+		if (memberPopup.isEmpty()) {
+			return true;
+		}
+		// 페이지에 방문하지 않은 경우 && 마지막으로 본 일자가 현재 보다 과거인 경우
+		return !memberPopup.get().getHasVisited() && memberPopup.get().getLastViewedAt().isBefore(LocalDate.now());
+	}
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/memberpopup/MemberPopupFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/memberpopup/MemberPopupFacadeService.java
@@ -1,0 +1,88 @@
+package kr.mashup.branding.facade.memberpopup;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.domain.member.exception.InactiveGenerationException;
+import kr.mashup.branding.domain.popup.MemberPopup;
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.service.memberpopup.MemberPopupService;
+import kr.mashup.branding.service.storage.StorageService;
+import kr.mashup.branding.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberPopupFacadeService {
+
+	private final MemberPopupService memberPopupService;
+	private final MemberService memberService;
+	private final StorageService storageService;
+
+	public List<String> getPossiblePopupKeys(
+		Long memberGenerationId
+	) {
+
+		List<String> possiblePopupKeys = new ArrayList<>();
+		MemberGeneration memberGeneration = memberService.findByMemberGenerationId(memberGenerationId);
+
+		// 멤버의 기수가 활동 중인 기수가 아닌 경우
+		if (!memberService.isActiveGeneration(memberGeneration)) {
+			return possiblePopupKeys;
+		}
+
+		// 현재 운영하는 팝업의 Storage key 와 운영기간(새로운 팝업 추가시 변경이 필요한 값)
+		String popupKey = "danggnPopup";
+		Storage storage = storageService.findByKey(popupKey);
+		LocalDate popupStartedAt = LocalDate.of(2023, 4, 1);
+		LocalDate popupEndedAt = LocalDate.of(2023, 5, 15);
+
+		if (DateUtil.isInTime(popupStartedAt, popupEndedAt, LocalDate.now())
+			&& memberPopupService.isPossibleMemberPopup(memberGeneration.getMember(), storage)) {
+			possiblePopupKeys.add(popupKey);
+		}
+		return possiblePopupKeys;
+	}
+
+	@Transactional
+	public void updateHasVisited(
+		Long memberGenerationId,
+		String popupType
+	) {
+
+		MemberPopup memberPopup = getUpdatableByMemberGenerationAndStorage(memberGenerationId, popupType);
+		memberPopup.updateHasVisited(true);
+	}
+
+	@Transactional
+	public void updateLastViewedAt(
+		Long memberGenerationId,
+		String popupType
+	) {
+
+		MemberPopup memberPopup = getUpdatableByMemberGenerationAndStorage(memberGenerationId, popupType);
+		memberPopup.updateLastViewedAt(LocalDate.now());
+	}
+
+	private MemberPopup getUpdatableByMemberGenerationAndStorage(
+		Long memberGenerationId,
+		String popupType
+	) {
+
+		Storage storage = storageService.findByKey(popupType);
+
+		MemberGeneration memberGeneration = memberService.findByMemberGenerationId(memberGenerationId);
+		if (!memberService.isActiveGeneration(memberGeneration)) {
+			throw new InactiveGenerationException();
+		}
+
+		return memberPopupService.findOrSaveMemberPopupByMemberAndStorage(memberGeneration.getMember(), storage);
+	}
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/memberpopup/MemberPopupController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/memberpopup/MemberPopupController.java
@@ -1,0 +1,82 @@
+package kr.mashup.branding.ui.memberpopup;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.memberpopup.MemberPopupFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.EmptyResponse;
+import lombok.RequiredArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RestController
+@RequestMapping("api/v1/member-popups")
+@RequiredArgsConstructor
+public class MemberPopupController {
+
+	private final MemberPopupFacadeService memberPopupFacadeService;
+
+	@ApiOperation(
+		value = "멤버가 볼 수 있는 팝업 조회",
+		notes =
+			"<h2>Error Code</h2>" +
+				"<p>" +
+				"MEMBER_GENERATION_NOT_FOUND</br>" +
+				"STORAGE_NOT_FOUND</br>" +
+				"</p>"
+
+	)
+	@GetMapping
+	public ApiResponse<List<String>> getPossiblePopupKeys(
+		@ApiIgnore MemberAuth memberAuth
+	) {
+		return ApiResponse.success(memberPopupFacadeService.getPossiblePopupKeys(memberAuth.getMemberGenerationId()));
+	}
+
+	@ApiOperation(
+		value = "페이지 방문 업데이트",
+		notes =
+			"<h2>Error Code</h2>" +
+				"<p>" +
+				"MEMBER_GENERATION_NOT_FOUND</br>" +
+				"STORAGE_NOT_FOUND</br>" +
+				"INACTIVE_GENERATION</br>" +
+				"</p>"
+
+	)
+	@PatchMapping("/{popupType}/visit")
+	public ApiResponse<EmptyResponse> updateIsVisible(
+		@ApiIgnore MemberAuth memberAuth,
+		@PathVariable String popupType
+	) {
+		memberPopupFacadeService.updateHasVisited(memberAuth.getMemberGenerationId(), popupType);
+		return ApiResponse.success();
+	}
+
+	@ApiOperation(
+		value = "팝업 마지막 본 시간 업데이트",
+		notes =
+			"<h2>Error Code</h2>" +
+				"<p>" +
+				"MEMBER_GENERATION_NOT_FOUND</br>" +
+				"STORAGE_NOT_FOUND</br>" +
+				"INACTIVE_GENERATION</br>" +
+				"</p>"
+
+	)
+	@PatchMapping("/{popupType}/last-viewed")
+	public ApiResponse<EmptyResponse> updateLastViewedAt(
+		@ApiIgnore MemberAuth memberAuth,
+		@PathVariable String popupType
+	) {
+		memberPopupFacadeService.updateLastViewedAt(memberAuth.getMemberGenerationId(), popupType);
+		return ApiResponse.success();
+	}
+}


### PR DESCRIPTION
## PR 타입
- 기능
## 개요
- 멤버 팝업 관련 API 추가
![image](https://user-images.githubusercontent.com/66551410/233885844-4175fdd1-0f17-42bd-bcd8-c4bb9a69214d.png)
- 멤버가 볼 수 있는 팝업 조회 API
  - 멤버의 기수가 현재 활동 중인 기수인 경우
  - 팝업이 운영기간인 경우 && 멤버가 아직 팝업 또는 페이지에 방문하지 않은 경우(MemberPopup 데이터 없음)
  - 팝업이 운영기간인 경우 && 페이지에 방문하지 않은 경우(`MemberPopup.hasVisited` false) && 마지막으로 본 일자가 현재 보다 과거인 경우
- 페이지 방문 업데이트 API
  -  페이지에 방문 유무 필드 true 로 업데이트(`MemberPopup.hasVisited` true)
- 팝업 마지막 본 시간 업데이트 API
  -  팝업 마지막으로 본 날짜 필드 현재로 업데이트(`MemberPopup.lastViewedAt` now)

-
1. 메인페에지에서 멤버가 볼 수 있는 팝업 조회 API 하여 storage의 key값 조회
2 .storage의 key 값으로 컴포넌트 value 조회
3. 팝업 띄울때, 팝업 마지막 본 시간 업데이트 API 호출
4. 페이지 방문 하는 경우,페이지 방문 업데이트 API 호출
##  변경사항

