### PR TITLE
feat: 당근 랭킹 회차 API 작업

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/ResultCode.java
@@ -107,6 +107,7 @@ public enum ResultCode {
 
     // Danggn
     TODAY_MESSAGE_NOT_FOUND("존재하지 않는 메시지입니다."),
+    RANKING_ROUND_NOT_FOUND("당근 랭킹 회차가 존재하지 않습니다."),
 
     // JsonUtil
     JSON_DESERIALIZE_UNABLE("객체를 json string 을 deserialize 할 수 없습니다"),

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnNotificationMemberRecord.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnNotificationMemberRecord.java
@@ -5,7 +5,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
+import javax.persistence.ManyToOne;
 
 import kr.mashup.branding.domain.member.MemberGeneration;
 import lombok.AccessLevel;
@@ -20,25 +20,30 @@ public class DanggnNotificationMemberRecord {
     @GeneratedValue
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_generation_id")
     private MemberGeneration memberGeneration;
 
     private Long lastNotificationSentScore;
 
+    private Long danggnRankingRoundId;
+
     public static DanggnNotificationMemberRecord of(
         MemberGeneration memberGeneration,
-        Long lastNotificationSentScore
+        Long lastNotificationSentScore,
+        Long danggnRankingRoundId
     ) {
-        return new DanggnNotificationMemberRecord(memberGeneration, lastNotificationSentScore);
+        return new DanggnNotificationMemberRecord(memberGeneration, lastNotificationSentScore, danggnRankingRoundId);
     }
 
     private DanggnNotificationMemberRecord(
         MemberGeneration memberGeneration,
-        Long lastNotificationSentScore
+        Long lastNotificationSentScore,
+        Long danggnRankingRoundId
     ) {
         this.memberGeneration = memberGeneration;
         this.lastNotificationSentScore = lastNotificationSentScore;
+        this.danggnRankingRoundId = danggnRankingRoundId;
     }
 
     public void updateLastNotificationSentScore(Long lastNotificationSentScore) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnNotificationPlatformRecord.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnNotificationPlatformRecord.java
@@ -32,22 +32,27 @@ public class DanggnNotificationPlatformRecord {
 
     private Long lastNotificationSentScore;
 
+    private Long danggnRankingRoundId;
+
     public static DanggnNotificationPlatformRecord of(
         Generation generation,
         Platform platform,
-        Long lastNotificationSentScore
+        Long lastNotificationSentScore,
+        Long danggnRankingRoundId
     ) {
-        return new DanggnNotificationPlatformRecord(generation, platform, lastNotificationSentScore);
+        return new DanggnNotificationPlatformRecord(generation, platform, lastNotificationSentScore, danggnRankingRoundId);
     }
 
     private DanggnNotificationPlatformRecord(
         Generation generation,
         Platform platform,
-        Long lastNotificationSentScore
+        Long lastNotificationSentScore,
+        Long danggnRankingRoundId
     ) {
         this.generation = generation;
         this.platform = platform;
         this.lastNotificationSentScore = lastNotificationSentScore;
+        this.danggnRankingRoundId = danggnRankingRoundId;
     }
 
     public void updateLastNotificationSentScore(Long lastNotificationSentScore) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
@@ -3,7 +3,6 @@ package kr.mashup.branding.domain.danggn;
 import javax.persistence.Entity;
 
 import kr.mashup.branding.domain.BaseEntity;
-import kr.mashup.branding.service.danggn.DanggnRankingRewardStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
@@ -1,0 +1,29 @@
+package kr.mashup.branding.domain.danggn;
+
+import javax.persistence.Entity;
+
+import kr.mashup.branding.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DanggnRankingReward extends BaseEntity {
+
+	private String comment;
+
+	private Long firstPlaceRecordMemberId;
+
+	private Long danggnRankingRoundId;
+
+	public static DanggnRankingReward from(Long firstPlaceRecordMemberGenerationId, Long danggnRankingRoundId) {
+		return new DanggnRankingReward(firstPlaceRecordMemberGenerationId, danggnRankingRoundId);
+	}
+
+	private DanggnRankingReward(Long firstPlaceRecordMemberId, Long danggnRankingRoundId) {
+		this.firstPlaceRecordMemberId = firstPlaceRecordMemberId;
+		this.danggnRankingRoundId = danggnRankingRoundId;
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingReward.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.domain.danggn;
 import javax.persistence.Entity;
 
 import kr.mashup.branding.domain.BaseEntity;
+import kr.mashup.branding.service.danggn.DanggnRankingRewardStatus;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,5 +26,10 @@ public class DanggnRankingReward extends BaseEntity {
 	private DanggnRankingReward(Long firstPlaceRecordMemberId, Long danggnRankingRoundId) {
 		this.firstPlaceRecordMemberId = firstPlaceRecordMemberId;
 		this.danggnRankingRoundId = danggnRankingRoundId;
+	}
+
+	public DanggnRankingRewardStatus getRankingRewardStatus() {
+		return this.getComment() == null ? DanggnRankingRewardStatus.FIRST_PLACE_MEMBER_NOT_REGISTERED :
+			DanggnRankingRewardStatus.FIRST_PLACE_MEMBER_REGISTERED;
 	}
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRewardStatus.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRewardStatus.java
@@ -1,4 +1,4 @@
-package kr.mashup.branding.service.danggn;
+package kr.mashup.branding.domain.danggn;
 
 public enum DanggnRankingRewardStatus {
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRewardStatus.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRewardStatus.java
@@ -2,12 +2,12 @@ package kr.mashup.branding.domain.danggn;
 
 public enum DanggnRankingRewardStatus {
 
-	NO_FIRST_PLACE_MEMBER,				// 회차가 진행되지 않아서 1등한 사람이 없는 경우
+	FIRST_PLACE_MEMBER_NOT_EXISTED,		// 1등한 사람이 없는 경우(1회차)
 	FIRST_PLACE_MEMBER_NOT_REGISTERED,	// 회차는 진행되었지만, 1등한 사람이 리워드를 등록하지 않은 경우
 	FIRST_PLACE_MEMBER_REGISTERED		// 회차가 진행되었고 1등한 사람이 리워드를 등록한 경우
 	;
 
 	public Boolean hasFirstPlaceMember() {
-		return this != NO_FIRST_PLACE_MEMBER;
+		return this != FIRST_PLACE_MEMBER_NOT_EXISTED;
 	}
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRound.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnRankingRound.java
@@ -1,0 +1,50 @@
+package kr.mashup.branding.domain.danggn;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DanggnRankingRound {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private Integer number;
+
+	private LocalDateTime startedAt;
+
+	private LocalDateTime endedAt;
+
+	private Long generationId;
+
+	public static DanggnRankingRound of(
+		Integer number,
+		LocalDateTime startedAt,
+		LocalDateTime endedAt,
+		Long generationId
+	) {
+		return new DanggnRankingRound(number, startedAt, endedAt, generationId);
+	}
+
+	private DanggnRankingRound(
+		Integer number,
+		LocalDateTime startedAt,
+		LocalDateTime endedAt,
+		Long generationId
+	) {
+		this.number = number;
+		this.startedAt = startedAt;
+		this.endedAt = endedAt;
+		this.generationId = generationId;
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/DanggnScore.java
@@ -1,14 +1,22 @@
 package kr.mashup.branding.domain.danggn;
 
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import kr.mashup.branding.domain.member.MemberGeneration;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,28 +27,33 @@ public class DanggnScore {
     @GeneratedValue
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_generation_id")
     private MemberGeneration memberGeneration;
 
     private Long totalShakeScore;
+
+    private Long danggnRankingRoundId;
 
     @LastModifiedDate
     protected LocalDateTime lastShakedAt;
 
     public static DanggnScore of(
         MemberGeneration memberGeneration,
-        Long totalShakeScore
+        Long totalShakeScore,
+        Long danggnRankingRoundId
     ) {
-        return new DanggnScore(memberGeneration, totalShakeScore);
+        return new DanggnScore(memberGeneration, totalShakeScore, danggnRankingRoundId);
     }
 
     private DanggnScore(
         MemberGeneration memberGeneration,
-        Long totalShakeScore
+        Long totalShakeScore,
+        Long danggnRankingRoundId
     ) {
         this.memberGeneration = memberGeneration;
         this.totalShakeScore = totalShakeScore;
+        this.danggnRankingRoundId = danggnRankingRoundId;
     }
 
     public void addScore(Long score) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/Exception/DanggnRankingRoundNotFoundException.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/danggn/Exception/DanggnRankingRoundNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.domain.danggn.Exception;
+
+import kr.mashup.branding.domain.ResultCode;
+import kr.mashup.branding.domain.exception.NotFoundException;
+
+public class DanggnRankingRoundNotFoundException extends NotFoundException {
+    public DanggnRankingRoundNotFoundException() {
+        super(ResultCode.RANKING_ROUND_NOT_FOUND);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnNotificationMemberRecordRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnNotificationMemberRecordRepository.java
@@ -9,7 +9,7 @@ import kr.mashup.branding.domain.member.MemberGeneration;
 
 public interface DanggnNotificationMemberRecordRepository extends JpaRepository<DanggnNotificationMemberRecord, Long> {
 
-	Optional<DanggnNotificationMemberRecord> findByMemberGeneration(MemberGeneration memberGeneration);
+	Optional<DanggnNotificationMemberRecord> findByMemberGenerationAndDanggnRankingRoundId(MemberGeneration memberGeneration, Long danggnRankingRoundId);
 
 	void deleteByMemberGeneration(MemberGeneration memberGeneration);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnNotificationPlatformRecordRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnNotificationPlatformRecordRepository.java
@@ -10,5 +10,5 @@ import kr.mashup.branding.domain.member.Platform;
 
 public interface DanggnNotificationPlatformRecordRepository extends JpaRepository<DanggnNotificationPlatformRecord, Long> {
 
-	Optional<DanggnNotificationPlatformRecord> findByPlatformAndGeneration(Platform platform, Generation generation);
+	Optional<DanggnNotificationPlatformRecord> findByPlatformAndGenerationAndDanggnRankingRoundId(Platform platform, Generation generation, Long danggnRankingRoundId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRewardRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRewardRepository.java
@@ -1,0 +1,12 @@
+package kr.mashup.branding.repository.danggn;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingReward;
+
+public interface DanggnRankingRewardRepository extends JpaRepository<DanggnRankingReward, Long> {
+
+	Optional<DanggnRankingReward> findByDanggnRankingRoundId(Long danggnRankingRoundId);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepository.java
@@ -1,0 +1,15 @@
+package kr.mashup.branding.repository.danggn;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+
+public interface DanggnRankingRoundRepository extends JpaRepository<DanggnRankingRound, Long> {
+
+	List<DanggnRankingRound> findByGenerationId(Long generationId);
+
+	Optional<DanggnRankingRound> findByNumberAndGenerationId(Integer number, Long generationId);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.mashup.branding.domain.danggn.DanggnRankingRound;
 
-public interface DanggnRankingRoundRepository extends JpaRepository<DanggnRankingRound, Long> {
+public interface DanggnRankingRoundRepository extends JpaRepository<DanggnRankingRound, Long>, DanggnRankingRoundRepositoryCustom {
 
 	List<DanggnRankingRound> findByGenerationId(Long generationId);
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepositoryCustom.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.repository.danggn;
+
+import java.util.Optional;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+
+public interface DanggnRankingRoundRepositoryCustom {
+
+	Optional<DanggnRankingRound> retrieveCurrentByGenerationNum(Integer generationNumber);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnRankingRoundRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package kr.mashup.branding.repository.danggn;
+
+import static kr.mashup.branding.domain.danggn.QDanggnRankingRound.*;
+import static kr.mashup.branding.domain.generation.QGeneration.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DanggnRankingRoundRepositoryCustomImpl implements DanggnRankingRoundRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Optional<DanggnRankingRound> retrieveCurrentByGenerationNum(Integer generationNumber) {
+
+		LocalDateTime now = LocalDateTime.now();
+
+		return Optional.ofNullable(queryFactory.selectFrom(danggnRankingRound)
+			.innerJoin(generation)
+			.on(danggnRankingRound.generationId.eq(generation.id))
+			.where(generation.number.eq(generationNumber)
+				.and(danggnRankingRound.startedAt.loe(now)
+					.and(danggnRankingRound.endedAt.goe(now))))
+			.fetchFirst());
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepository.java
@@ -8,7 +8,7 @@ import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.member.MemberGeneration;
 
 public interface DanggnScoreRepository extends JpaRepository<DanggnScore, Long>, DanggnScoreRepositoryCustom {
-    Optional<DanggnScore> findByMemberGeneration(MemberGeneration memberGeneration);
+    Optional<DanggnScore> findByMemberGenerationAndDanggnRankingRoundId(MemberGeneration memberGeneration, Long danggnRankingRoundId);
 
     void deleteByMemberGeneration(MemberGeneration memberGeneration);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepositoryCustom.java
@@ -1,12 +1,12 @@
 package kr.mashup.branding.repository.danggn;
 
+import java.util.List;
+
 import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.repository.danggn.DanggnScoreRepositoryCustomImpl.DanggnScorePlatformQueryResult;
 
-import java.util.List;
-
 public interface DanggnScoreRepositoryCustom {
-    List<DanggnScore> findOrderedListByGenerationNum(Integer generationNumber);
+    List<DanggnScore> findOrderedListByGenerationNum(Integer generationNumber, Long danggnRankingRoundId);
 
-    List<DanggnScorePlatformQueryResult> findOrderedDanggnScorePlatformListByGenerationNum(Integer generationNumber);
+    List<DanggnScorePlatformQueryResult> findOrderedDanggnScorePlatformListByGenerationNum(Integer generationNumber, Long danggnRankingRoundId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/danggn/DanggnScoreRepositoryCustomImpl.java
@@ -1,34 +1,36 @@
 package kr.mashup.branding.repository.danggn;
 
+import static kr.mashup.branding.domain.danggn.QDanggnScore.*;
+import static kr.mashup.branding.domain.generation.QGeneration.*;
+import static kr.mashup.branding.domain.member.QMemberGeneration.*;
+
+import java.util.List;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.member.Platform;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
-
-import static kr.mashup.branding.domain.danggn.QDanggnScore.danggnScore;
-import static kr.mashup.branding.domain.generation.QGeneration.generation;
-import static kr.mashup.branding.domain.member.QMemberGeneration.memberGeneration;
 
 @RequiredArgsConstructor
 public class DanggnScoreRepositoryCustomImpl implements DanggnScoreRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<DanggnScore> findOrderedListByGenerationNum(Integer generationNumber) {
+    public List<DanggnScore> findOrderedListByGenerationNum(Integer generationNumber, Long danggnRankingRoundId) {
         return queryFactory.selectFrom(danggnScore)
             .innerJoin(danggnScore.memberGeneration, memberGeneration)
             .innerJoin(memberGeneration.generation, generation)
             .on(generation.number.eq(generationNumber))
+            .where(danggnScore.danggnRankingRoundId.eq(danggnRankingRoundId))
             .orderBy(danggnScore.totalShakeScore.desc(), danggnScore.lastShakedAt.asc())
             .fetch();
     }
 
     @Override
-    public List<DanggnScorePlatformQueryResult> findOrderedDanggnScorePlatformListByGenerationNum(Integer generationNumber) {
+    public List<DanggnScorePlatformQueryResult> findOrderedDanggnScorePlatformListByGenerationNum(Integer generationNumber, Long danggnRankingRoundId) {
         return queryFactory
             .select(
                 Projections.fields(DanggnScorePlatformQueryResult.class,
@@ -40,6 +42,7 @@ public class DanggnScoreRepositoryCustomImpl implements DanggnScoreRepositoryCus
             .innerJoin(danggnScore.memberGeneration, memberGeneration)
             .innerJoin(memberGeneration.generation, generation)
             .on(generation.number.eq(generationNumber))
+            .where(danggnScore.danggnRankingRoundId.eq(danggnRankingRoundId))
             .groupBy(memberGeneration.platform)
             .orderBy(
                 danggnScore.totalShakeScore.sum().desc(),

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnCacheService.java
@@ -20,13 +20,13 @@ public class DanggnCacheService {
     private final DanggnScoreRepository danggnScoreRepository;
 
     @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "T(kr.mashup.branding.service.danggn.DanggnCacheKey).MEMBER + #generationNumber.toString()")
-    public String getCachedFirstRecordMemberId(Integer generationNumber) {
-        return findFirstRecordMember(generationNumber).getId().toString();
+    public String getCachedFirstRecordMemberId(Integer generationNumber, Long danggnRankingRoundId) {
+        return findFirstRecordMember(generationNumber, danggnRankingRoundId).getId().toString();
     }
 
     @Cacheable(cacheNames = "danggnFirstPlaceRecord", key = "T(kr.mashup.branding.service.danggn.DanggnCacheKey).PLATFORM + #generationNumber.toString()")
-    public String getCachedFirstRecordPlatform(Integer generationNumber) {
-        return findFirstRecordPlatform(generationNumber).toString();
+    public String getCachedFirstRecordPlatform(Integer generationNumber, Long danggnRankingRoundId) {
+        return findFirstRecordPlatform(generationNumber, danggnRankingRoundId).toString();
     }
 
     @CachePut(cacheNames = "danggnFirstPlaceRecord", key = "#key + #generationNumber.toString()")
@@ -34,8 +34,8 @@ public class DanggnCacheService {
         return value;
     }
 
-    public Member findFirstRecordMember(Integer generationNumber) {
-        List<DanggnScore> danggnScores = danggnScoreRepository.findOrderedListByGenerationNum(generationNumber);
+    public Member findFirstRecordMember(Integer generationNumber, Long danggnRankingRoundId) {
+        List<DanggnScore> danggnScores = danggnScoreRepository.findOrderedListByGenerationNum(generationNumber, danggnRankingRoundId);
 
         if (danggnScores.isEmpty()) {
             return null;
@@ -45,8 +45,8 @@ public class DanggnCacheService {
                 .getMember();
     }
 
-    public Platform findFirstRecordPlatform(Integer generationNumber) {
-        List<DanggnScorePlatformQueryResult> results = danggnScoreRepository.findOrderedDanggnScorePlatformListByGenerationNum(generationNumber);
+    public Platform findFirstRecordPlatform(Integer generationNumber, Long danggnRankingRoundId) {
+        List<DanggnScorePlatformQueryResult> results = danggnScoreRepository.findOrderedDanggnScorePlatformListByGenerationNum(generationNumber, danggnRankingRoundId);
 
         if (results.isEmpty()) {
             return null;

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnNotificationRecordService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnNotificationRecordService.java
@@ -19,13 +19,13 @@ public class DanggnNotificationRecordService {
 
 	private final DanggnNotificationPlatformRecordRepository danggnNotificationPlatformRecordRepository;
 
-	public DanggnNotificationMemberRecord findMemberRecordOrSave(MemberGeneration memberGeneration) {
-		return danggnNotificationMemberRecordRepository.findByMemberGeneration(memberGeneration)
-			.orElseGet(() -> danggnNotificationMemberRecordRepository.save(DanggnNotificationMemberRecord.of(memberGeneration, 0L)));
+	public DanggnNotificationMemberRecord findMemberRecordOrSave(MemberGeneration memberGeneration, Long danggnRankingRoundId) {
+		return danggnNotificationMemberRecordRepository.findByMemberGenerationAndDanggnRankingRoundId(memberGeneration, danggnRankingRoundId)
+			.orElseGet(() -> danggnNotificationMemberRecordRepository.save(DanggnNotificationMemberRecord.of(memberGeneration, 0L, danggnRankingRoundId)));
 	}
 
-	public DanggnNotificationPlatformRecord findPlatformRecordOrSave(Generation generation, Platform platform) {
-		return danggnNotificationPlatformRecordRepository.findByPlatformAndGeneration(platform, generation)
-			.orElseGet(() -> danggnNotificationPlatformRecordRepository.save(DanggnNotificationPlatformRecord.of(generation, platform, 0L)));
+	public DanggnNotificationPlatformRecord findPlatformRecordOrSave(Generation generation, Platform platform, Long danggnRankingRoundId) {
+		return danggnNotificationPlatformRecordRepository.findByPlatformAndGenerationAndDanggnRankingRoundId(platform, generation, danggnRankingRoundId)
+			.orElseGet(() -> danggnNotificationPlatformRecordRepository.save(DanggnNotificationPlatformRecord.of(generation, platform, 0L, danggnRankingRoundId)));
 	}
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRewardService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRewardService.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.service.danggn;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingReward;
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import kr.mashup.branding.repository.danggn.DanggnRankingRewardRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnRankingRewardService {
+
+	private final DanggnRankingRewardRepository danggnRankingRewardRepository;
+
+	public DanggnRankingReward findByDanggnRankingRoundOrNull(Optional<DanggnRankingRound> danggnRankingRound) {
+		return danggnRankingRound.flatMap(round -> danggnRankingRewardRepository.findByDanggnRankingRoundId(round.getId()))
+			.orElse(null);
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRewardStatus.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRewardStatus.java
@@ -1,0 +1,13 @@
+package kr.mashup.branding.service.danggn;
+
+public enum DanggnRankingRewardStatus {
+
+	NO_FIRST_PLACE_MEMBER,				// 회차가 진행되지 않아서 1등한 사람이 없는 경우
+	FIRST_PLACE_MEMBER_NOT_REGISTERED,	// 회차는 진행되었지만, 1등한 사람이 리워드를 등록하지 않은 경우
+	FIRST_PLACE_MEMBER_REGISTERED		// 회차가 진행되었고 1등한 사람이 리워드를 등록한 경우
+	;
+
+	public Boolean hasFirstPlaceMember() {
+		return this != NO_FIRST_PLACE_MEMBER;
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRoundService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRoundService.java
@@ -1,0 +1,50 @@
+package kr.mashup.branding.service.danggn;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import kr.mashup.branding.domain.danggn.Exception.DanggnRankingRoundNotFoundException;
+import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.repository.danggn.DanggnRankingRoundRepository;
+import kr.mashup.branding.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DanggnRankingRoundService {
+
+	private final DanggnRankingRoundRepository danggnRankingRoundRepository;
+
+	public DanggnRankingRound findCurrentByGeneration(Generation generation) {
+		return danggnRankingRoundRepository.findByGenerationId(generation.getId())
+			.stream()
+			.filter(round -> DateUtil.isInTime(round.getStartedAt(), round.getEndedAt(), LocalDateTime.now()))
+			.findFirst()
+			.orElseThrow(DanggnRankingRoundNotFoundException::new);
+	}
+
+	public DanggnRankingRound findByIdOrThrow(Long id) {
+		return danggnRankingRoundRepository.findById(id)
+			.orElseThrow(DanggnRankingRoundNotFoundException::new);
+	}
+
+	public Optional<DanggnRankingRound> getPreviousById(Long id) {
+		DanggnRankingRound current =  danggnRankingRoundRepository.findById(id)
+			.orElseThrow(DanggnRankingRoundNotFoundException::new);
+		return danggnRankingRoundRepository.findByNumberAndGenerationId(current.getNumber() - 1, current.getGenerationId());
+	}
+
+	public List<DanggnRankingRound> findPastAndCurrentByGeneration(Generation generation) {
+		return danggnRankingRoundRepository.findByGenerationId(generation.getId())
+			.stream()
+			.filter(round -> DateUtil.isStartBeforeOrEqualEnd(round.getStartedAt(), LocalDateTime.now()))
+			.sorted(Comparator.comparingInt(DanggnRankingRound::getNumber).reversed())
+			.collect(Collectors.toList());
+	}
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRoundService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnRankingRoundService.java
@@ -21,11 +21,8 @@ public class DanggnRankingRoundService {
 
 	private final DanggnRankingRoundRepository danggnRankingRoundRepository;
 
-	public DanggnRankingRound findCurrentByGeneration(Generation generation) {
-		return danggnRankingRoundRepository.findByGenerationId(generation.getId())
-			.stream()
-			.filter(round -> DateUtil.isInTime(round.getStartedAt(), round.getEndedAt(), LocalDateTime.now()))
-			.findFirst()
+	public DanggnRankingRound findCurrentByGeneration(Integer generationNumber) {
+		return danggnRankingRoundRepository.retrieveCurrentByGenerationNum(generationNumber)
 			.orElseThrow(DanggnRankingRoundNotFoundException::new);
 	}
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnScoreService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/danggn/DanggnScoreService.java
@@ -1,29 +1,30 @@
 package kr.mashup.branding.service.danggn;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.repository.danggn.DanggnScoreRepository;
 import kr.mashup.branding.repository.danggn.DanggnScoreRepositoryCustomImpl.DanggnScorePlatformQueryResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class DanggnScoreService {
     private final DanggnScoreRepository danggnScoreRepository;
 
-    public DanggnScore findByMemberGeneration(MemberGeneration memberGeneration) {
-        return danggnScoreRepository.findByMemberGeneration(memberGeneration)
-            .orElseGet(() -> danggnScoreRepository.save(DanggnScore.of(memberGeneration, 0L)));
+    public DanggnScore findByMemberGenerationOrSave(MemberGeneration memberGeneration, Long danggnRankingRoundId) {
+        return danggnScoreRepository.findByMemberGenerationAndDanggnRankingRoundId(memberGeneration, danggnRankingRoundId)
+            .orElseGet(() -> danggnScoreRepository.save(DanggnScore.of(memberGeneration, 0L, danggnRankingRoundId)));
     }
 
-    public List<DanggnScore> getDanggnScoreOrderedList(Integer generationNumber) {
-        return danggnScoreRepository.findOrderedListByGenerationNum(generationNumber);
+    public List<DanggnScore> getDanggnScoreOrderedList(Integer generationNumber, Long danggnRankingRoundId) {
+        return danggnScoreRepository.findOrderedListByGenerationNum(generationNumber, danggnRankingRoundId);
     }
 
-    public List<DanggnScorePlatformQueryResult> getDanggnScorePlatformOrderedList(Integer generationNumber) {
-        return danggnScoreRepository.findOrderedDanggnScorePlatformListByGenerationNum(generationNumber);
+    public List<DanggnScorePlatformQueryResult> getDanggnScorePlatformOrderedList(Integer generationNumber, Long danggnRankingRoundId) {
+        return danggnScoreRepository.findOrderedDanggnScorePlatformListByGenerationNum(generationNumber, danggnRankingRoundId);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/util/DateUtil.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/util/DateUtil.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 public class DateUtil {
 
@@ -62,4 +63,10 @@ public class DateUtil {
         return fromEpoch(Long.parseLong(epochSecond));
     }
 
+    public static Integer countDayFromNow(LocalDateTime startedAt, LocalDateTime currentTime) {
+        return (int) ChronoUnit.DAYS.between(
+            currentTime.truncatedTo(ChronoUnit.DAYS),
+            startedAt.truncatedTo(ChronoUnit.DAYS)
+        );
+    }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.facade.danggn;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -11,10 +12,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.mashup.branding.domain.danggn.DanggnRankingReward;
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
 import kr.mashup.branding.domain.danggn.DanggnScore;
 import kr.mashup.branding.domain.danggn.DanggnTodayMessage;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.service.danggn.DanggnRankingRewardService;
+import kr.mashup.branding.service.danggn.DanggnRankingRoundService;
 import kr.mashup.branding.service.danggn.DanggnScoreService;
 import kr.mashup.branding.service.danggn.DanggnShakeLogService;
 import kr.mashup.branding.service.danggn.DanggnTodayMessageService;
@@ -22,6 +27,9 @@ import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.danggn.response.DanggnMemberRankData;
 import kr.mashup.branding.ui.danggn.response.DanggnPlatformRankResponse;
 import kr.mashup.branding.ui.danggn.response.DanggnRandomMessageResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse.DanggnRankingRewardResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundsResponse;
 import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +45,10 @@ public class DanggnFacadeService {
     private final DanggnScoreService danggnScoreService;
 
     private final DanggnTodayMessageService danggnTodayMessageService;
+
+    private final DanggnRankingRoundService danggnRankingRoundService;
+
+    private final DanggnRankingRewardService danggnRankingRewardService;
 
     @Transactional
     public DanggnScoreResponse addScore(Long memberGenerationId, Long score) {
@@ -75,6 +87,24 @@ public class DanggnFacadeService {
         return DanggnRandomMessageResponse.from(danggnTodayMessageList.get(0));
     }
 
+    @Transactional
+    public DanggnRankingRoundResponse getRankingRoundById(Long danggnRankingRoundId) {
+        final DanggnRankingRound currentDanggnRankingRound = danggnRankingRoundService.findByIdOrThrow(danggnRankingRoundId);
+        final Optional<DanggnRankingRound> previousDanggnRankingRound = danggnRankingRoundService.getPreviousById(danggnRankingRoundId);
+
+        final DanggnRankingRewardResponse rewardResponse = getDanggnRankingRewardResponse(previousDanggnRankingRound);
+        return DanggnRankingRoundResponse.of(currentDanggnRankingRound, rewardResponse);
+    }
+
+    public DanggnRankingRoundsResponse getAllRankingRoundByMemberGeneration(Long memberGenerationId) {
+        final MemberGeneration memberGeneration = memberService.findByMemberGenerationId(memberGenerationId);
+        List<DanggnRankingRoundsResponse.DanggnRankingRoundSimpleResponse> simpleResponses = danggnRankingRoundService.findPastAndCurrentByGeneration(memberGeneration.getGeneration())
+            .stream()
+            .map(DanggnRankingRoundsResponse.DanggnRankingRoundSimpleResponse::from)
+            .collect(Collectors.toList());
+        return DanggnRankingRoundsResponse.from(simpleResponses);
+    }
+
     private List<DanggnPlatformRankResponse> getExistingPlatformRankList(Integer generationNumber) {
         return danggnScoreService.getDanggnScorePlatformOrderedList(generationNumber).stream()
             .map(queryResult -> DanggnPlatformRankResponse.of(queryResult.getPlatform(), queryResult.getTotalScore()))
@@ -88,5 +118,15 @@ public class DanggnFacadeService {
             .collect(Collectors.toSet());
         entirePlatforms.removeAll(existingPlatforms);
         return entirePlatforms;
+    }
+
+    private DanggnRankingRewardResponse getDanggnRankingRewardResponse(Optional<DanggnRankingRound> danggnRankingRound) {
+
+        final DanggnRankingReward danggnRankingReward = danggnRankingRound.isPresent() ? danggnRankingRewardService.findByDanggnRankingRoundOrNull(danggnRankingRound) : null;
+
+        String name = danggnRankingReward != null ?
+            memberService.getActiveOrThrowById(danggnRankingReward.getFirstPlaceRecordMemberId()).getName() : null;
+        String comment = danggnRankingReward != null ? danggnRankingReward.getComment() : null;
+        return DanggnRankingRewardResponse.of(name, comment);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -20,7 +20,7 @@ import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.Platform;
 import kr.mashup.branding.service.danggn.DanggnRankingRewardService;
-import kr.mashup.branding.service.danggn.DanggnRankingRewardStatus;
+import kr.mashup.branding.domain.danggn.DanggnRankingRewardStatus;
 import kr.mashup.branding.service.danggn.DanggnRankingRoundService;
 import kr.mashup.branding.service.danggn.DanggnScoreService;
 import kr.mashup.branding.service.danggn.DanggnShakeLogService;

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/danggn/DanggnFacadeService.java
@@ -1,39 +1,21 @@
 package kr.mashup.branding.facade.danggn;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import kr.mashup.branding.domain.danggn.*;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.service.danggn.*;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.ui.danggn.response.*;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse.DanggnRankingRewardResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import kr.mashup.branding.domain.danggn.DanggnRankingReward;
-import kr.mashup.branding.domain.danggn.DanggnRankingRound;
-import kr.mashup.branding.domain.danggn.DanggnScore;
-import kr.mashup.branding.domain.danggn.DanggnTodayMessage;
-import kr.mashup.branding.domain.member.Member;
-import kr.mashup.branding.domain.member.MemberGeneration;
-import kr.mashup.branding.domain.member.Platform;
-import kr.mashup.branding.service.danggn.DanggnRankingRewardService;
-import kr.mashup.branding.domain.danggn.DanggnRankingRewardStatus;
-import kr.mashup.branding.service.danggn.DanggnRankingRoundService;
-import kr.mashup.branding.service.danggn.DanggnScoreService;
-import kr.mashup.branding.service.danggn.DanggnShakeLogService;
-import kr.mashup.branding.service.danggn.DanggnTodayMessageService;
-import kr.mashup.branding.service.member.MemberService;
-import kr.mashup.branding.ui.danggn.response.DanggnMemberRankData;
-import kr.mashup.branding.ui.danggn.response.DanggnPlatformRankResponse;
-import kr.mashup.branding.ui.danggn.response.DanggnRandomMessageResponse;
-import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse;
-import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse.DanggnRankingRewardResponse;
-import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundsResponse;
-import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -114,6 +96,7 @@ public class DanggnFacadeService {
         final DanggnRankingRound currentDanggnRankingRound = danggnRankingRoundService.findByIdOrThrow(danggnRankingRoundId);
         final Optional<DanggnRankingRound> previousDanggnRankingRound = danggnRankingRoundService.getPreviousById(danggnRankingRoundId);
 
+        // 조회하는 회차의 전 회차 1등 공지사항 조회
         final DanggnRankingRewardResponse rewardResponse = getDanggnRankingRewardResponse(previousDanggnRankingRound);
         return DanggnRankingRoundResponse.of(currentDanggnRankingRound, rewardResponse);
     }
@@ -137,7 +120,7 @@ public class DanggnFacadeService {
 
         final DanggnRankingReward reward = danggnRankingRewardService.findByDanggnRankingRoundOrNull(danggnRankingRound);
         final DanggnRankingRewardStatus status =
-            reward == null ? DanggnRankingRewardStatus.NO_FIRST_PLACE_MEMBER : reward.getRankingRewardStatus();
+            reward == null ? DanggnRankingRewardStatus.FIRST_PLACE_MEMBER_NOT_EXISTED : reward.getRankingRewardStatus();
 
         final Member member = status.hasFirstPlaceMember() ? memberService.getActiveOrThrowById(reward.getFirstPlaceRecordMemberId()) : null;
         return DanggnRankingRewardResponse.of(reward, member, status);

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
@@ -1,24 +1,33 @@
 package kr.mashup.branding.ui.danggn;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.aop.cipher.CheckApiCipherTime;
-import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.facade.danggn.DanggnFacadeService;
 import kr.mashup.branding.security.MemberAuth;
 import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.danggn.request.DanggnScoreAddRequest;
-import kr.mashup.branding.ui.danggn.response.*;
-import kr.mashup.branding.util.CipherUtil;
-import kr.mashup.branding.util.DateUtil;
+import kr.mashup.branding.ui.danggn.response.DanggnMemberRankData;
+import kr.mashup.branding.ui.danggn.response.DanggnMemberRankResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnPlatformRankResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRandomMessageResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnRankingRoundsResponse;
+import kr.mashup.branding.ui.danggn.response.DanggnScoreResponse;
+import kr.mashup.branding.ui.danggn.response.GoldenDanggnPercentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
-
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -90,4 +99,15 @@ public class DanggnController {
         return ApiResponse.success(danggnFacadeService.getRandomTodayMessage());
     }
 
+    @ApiOperation(value = "당근 랭킹 회차 다건 조회")
+    @GetMapping("/ranking-round")
+    public ApiResponse<DanggnRankingRoundsResponse> getAllRankingRound(@ApiIgnore MemberAuth auth) {
+        return ApiResponse.success(danggnFacadeService.getAllRankingRoundByMemberGeneration(auth.getMemberGenerationId()));
+    }
+
+    @ApiOperation(value = "당근 랭킹 회차 단건 조회")
+    @GetMapping("/ranking-round/{danggnRankingRoundId}")
+    public ApiResponse<DanggnRankingRoundResponse> getRankingRoundById(@PathVariable Long danggnRankingRoundId) {
+        return ApiResponse.success(danggnFacadeService.getRankingRoundById(danggnRankingRoundId));
+    }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/DanggnController.java
@@ -62,19 +62,21 @@ public class DanggnController {
     @GetMapping("/rank/member")
     public ApiResponse<List<DanggnMemberRankData>> getMemberRank(
         @RequestParam(defaultValue = "13", required = false) Integer generationNumber,
-        @RequestParam(defaultValue = "11", required = false) Integer limit
+        @RequestParam(defaultValue = "11", required = false) Integer limit,
+        @RequestParam(required = false) Long danggnRankingRoundId
     ) {
-        List<DanggnMemberRankData> danggnMemberRankDataList = danggnFacadeService.getMemberRankList(generationNumber);
+        List<DanggnMemberRankData> danggnMemberRankDataList = danggnFacadeService.getMemberRankList(generationNumber, danggnRankingRoundId);
         return ApiResponse.success(danggnMemberRankDataList.subList(0, Math.min(danggnMemberRankDataList.size(), limit)));
     }
 
     @ApiOperation(value = "당근 흔들기 개인별 랭킹 전체")
     @GetMapping("/rank/member/all")
     public ApiResponse<DanggnMemberRankResponse> getAllMemberRank(
-        @RequestParam(defaultValue = "13", required = false) Integer generationNumber
+        @RequestParam(defaultValue = "13", required = false) Integer generationNumber,
+        @RequestParam(required = false) Long danggnRankingRoundId
     ) {
         return ApiResponse.success(DanggnMemberRankResponse.of(
-            danggnFacadeService.getMemberRankList(generationNumber),
+            danggnFacadeService.getMemberRankList(generationNumber, danggnRankingRoundId),
             11
         ));
     }
@@ -82,9 +84,10 @@ public class DanggnController {
     @ApiOperation(value = "당근 흔들기 플랫폼별 랭킹")
     @GetMapping("/rank/platform")
     public ApiResponse<List<DanggnPlatformRankResponse>> getPlatformRank(
-        @RequestParam(defaultValue = "13", required = false) Integer generationNumber
+        @RequestParam(defaultValue = "13", required = false) Integer generationNumber,
+        @RequestParam(required = false) Long danggnRankingRoundId
     ) {
-        return ApiResponse.success(danggnFacadeService.getPlatformRankList(generationNumber));
+        return ApiResponse.success(danggnFacadeService.getPlatformRankList(generationNumber, danggnRankingRoundId));
     }
 
     @ApiOperation(value = "황금 당근 확률")

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import kr.mashup.branding.domain.danggn.DanggnRankingReward;
 import kr.mashup.branding.domain.danggn.DanggnRankingRound;
 import kr.mashup.branding.domain.member.Member;
-import kr.mashup.branding.service.danggn.DanggnRankingRewardStatus;
+import kr.mashup.branding.domain.danggn.DanggnRankingRewardStatus;
 import kr.mashup.branding.util.DateUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
@@ -1,15 +1,14 @@
 package kr.mashup.branding.ui.danggn.response;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
 import kr.mashup.branding.domain.danggn.DanggnRankingReward;
+import kr.mashup.branding.domain.danggn.DanggnRankingRewardStatus;
 import kr.mashup.branding.domain.danggn.DanggnRankingRound;
 import kr.mashup.branding.domain.member.Member;
-import kr.mashup.branding.domain.danggn.DanggnRankingRewardStatus;
 import kr.mashup.branding.util.DateUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
@@ -17,9 +16,9 @@ public class DanggnRankingRoundResponse {
 
 	Integer number;
 
-	LocalDate startDate;
+	LocalDateTime startDate;
 
-	LocalDate endDate;
+	LocalDateTime endDate;
 
 	Integer dateCount;
 
@@ -28,8 +27,8 @@ public class DanggnRankingRoundResponse {
 	public static DanggnRankingRoundResponse of(DanggnRankingRound danggnRankingRound, DanggnRankingRewardResponse danggnRankingReward) {
 		return new DanggnRankingRoundResponse(
 			danggnRankingRound.getNumber(),
-			danggnRankingRound.getStartedAt().toLocalDate(),
-			danggnRankingRound.getEndedAt().toLocalDate(),
+			danggnRankingRound.getStartedAt(),
+			danggnRankingRound.getEndedAt(),
 			DateUtil.countDayFromNow(danggnRankingRound.getEndedAt(), LocalDateTime.now()),
 			danggnRankingReward
 		);

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
@@ -1,0 +1,38 @@
+package kr.mashup.branding.ui.danggn.response;
+
+import java.time.LocalDate;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Value;
+
+@AllArgsConstructor
+@Getter
+public class DanggnRankingRoundResponse {
+
+	Integer number;
+
+	LocalDate startedAt;
+
+	LocalDate endedAt;
+
+	DanggnRankingRewardResponse danggnRankingReward;
+
+	public static DanggnRankingRoundResponse of(DanggnRankingRound danggnRankingRound, DanggnRankingRewardResponse danggnRankingReward) {
+		return new DanggnRankingRoundResponse(
+			danggnRankingRound.getNumber(),
+			danggnRankingRound.getStartedAt().toLocalDate(),
+			danggnRankingRound.getEndedAt().toLocalDate(),
+			danggnRankingReward
+		);
+	}
+
+	@Value(staticConstructor = "of")
+	public static class DanggnRankingRewardResponse {
+
+		String name;
+
+		String comment;
+	}
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
@@ -3,11 +3,13 @@ package kr.mashup.branding.ui.danggn.response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import kr.mashup.branding.domain.danggn.DanggnRankingReward;
 import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.service.danggn.DanggnRankingRewardStatus;
 import kr.mashup.branding.util.DateUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Value;
 
 @AllArgsConstructor
 @Getter
@@ -15,9 +17,9 @@ public class DanggnRankingRoundResponse {
 
 	Integer number;
 
-	LocalDate startedAt;
+	LocalDate startDate;
 
-	LocalDate endedAt;
+	LocalDate endDate;
 
 	Integer dateCount;
 
@@ -33,11 +35,25 @@ public class DanggnRankingRoundResponse {
 		);
 	}
 
-	@Value(staticConstructor = "of")
+	@AllArgsConstructor
+	@Getter
 	public static class DanggnRankingRewardResponse {
+
+		Long id;
 
 		String name;
 
 		String comment;
+
+		DanggnRankingRewardStatus status;
+
+		public static DanggnRankingRewardResponse of(DanggnRankingReward danggnRankingReward, Member member, DanggnRankingRewardStatus danggnRankingRewardStatus) {
+			return new DanggnRankingRewardResponse(
+				danggnRankingRewardStatus.hasFirstPlaceMember() ? danggnRankingReward.getId() : null,
+				danggnRankingRewardStatus.hasFirstPlaceMember() ? member.getName() : null,
+				danggnRankingRewardStatus.hasFirstPlaceMember() ? danggnRankingReward.getComment() : null,
+				danggnRankingRewardStatus
+			);
+		}
 	}
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundResponse.java
@@ -1,8 +1,10 @@
 package kr.mashup.branding.ui.danggn.response;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import kr.mashup.branding.util.DateUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
@@ -17,6 +19,8 @@ public class DanggnRankingRoundResponse {
 
 	LocalDate endedAt;
 
+	Integer dateCount;
+
 	DanggnRankingRewardResponse danggnRankingReward;
 
 	public static DanggnRankingRoundResponse of(DanggnRankingRound danggnRankingRound, DanggnRankingRewardResponse danggnRankingReward) {
@@ -24,6 +28,7 @@ public class DanggnRankingRoundResponse {
 			danggnRankingRound.getNumber(),
 			danggnRankingRound.getStartedAt().toLocalDate(),
 			danggnRankingRound.getEndedAt().toLocalDate(),
+			DateUtil.countDayFromNow(danggnRankingRound.getEndedAt(), LocalDateTime.now()),
 			danggnRankingReward
 		);
 	}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundsResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundsResponse.java
@@ -1,0 +1,38 @@
+package kr.mashup.branding.ui.danggn.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import kr.mashup.branding.domain.danggn.DanggnRankingRound;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Value;
+
+@Value(staticConstructor = "from")
+@Getter
+public class DanggnRankingRoundsResponse {
+
+	List<DanggnRankingRoundSimpleResponse> DanggnRankingRounds;
+
+	@AllArgsConstructor
+	@Getter
+	public static class DanggnRankingRoundSimpleResponse {
+
+		Long danggnRankingRoundId;
+
+		Integer number;
+
+		LocalDate startedAt;
+
+		LocalDate endedAt;
+
+		public static DanggnRankingRoundSimpleResponse from(DanggnRankingRound danggnRankingRound) {
+			return new DanggnRankingRoundSimpleResponse(
+				danggnRankingRound.getId(),
+				danggnRankingRound.getNumber(),
+				danggnRankingRound.getStartedAt().toLocalDate(),
+				danggnRankingRound.getEndedAt().toLocalDate()
+			);
+		}
+	}
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundsResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/danggn/response/DanggnRankingRoundsResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.Value;
 
 @Value(staticConstructor = "from")
-@Getter
 public class DanggnRankingRoundsResponse {
 
 	List<DanggnRankingRoundSimpleResponse> DanggnRankingRounds;
@@ -18,13 +17,13 @@ public class DanggnRankingRoundsResponse {
 	@Getter
 	public static class DanggnRankingRoundSimpleResponse {
 
-		Long danggnRankingRoundId;
+		Long id;
 
 		Integer number;
 
-		LocalDate startedAt;
+		LocalDate startDate;
 
-		LocalDate endedAt;
+		LocalDate endDate;
 
 		public static DanggnRankingRoundSimpleResponse from(DanggnRankingRound danggnRankingRound) {
 			return new DanggnRankingRoundSimpleResponse(


### PR DESCRIPTION
## PR 타입

## 개요
- 당근 랭킹 회차 단건 API 작업
<img width="653" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/b7da6fee-cc9d-4817-8f87-656eedb8dee1">

- 예시 응답값  
```json
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "number": 2,
    "startDate": "2023-06-18",
    "endDate": "2023-06-20",
    "dateCount": 2,
    "danggnRankingReward": {
      "id": 1,
      "name": "호선우",
      "comment": null,
      "status": "FIRST_PLACE_MEMBER_NOT_REGISTERED"
    }
  }
}
```

- 당근 랭킹 회차 다건 API 작업
<img width="653" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/52b9034a-344b-4c5b-925e-49924606fe17">

- 예시 응답값
```json
{
  "code": "SUCCESS",
  "message": "성공",
  "data": {
    "danggnRankingRounds": [
      {
        "id": 2,
        "number": 2,
        "startDate": "2023-06-18",
        "endDate": "2023-06-20"
      },
      {
        "id": 1,
        "number": 1,
        "startDate": "2023-06-18",
        "endDate": "2023-06-18"
      }
    ]
  }
}
```
- danggn_score, danggn_notification_member_record, danggn_notification_platform_record 테이블에 danggn_ranking_round_id 필드 추가
- 당근 랭킹 조회 API는 파라미터로 danggnRankingRoundId 넘겨주지 않으면 현재 운영중인 회차 기준으로 조회
- 당근 점수 추가 API는 danggnRankingRoundId를 넘겨받지 않고, 현재 운영중인 회차 기준으로 점수 추가 / 생성

##  변경사항

