### PR TITLE
feat: 당근 업데이트 알림 팝업 타입 추가

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/PopupType.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/popup/PopupType.java
@@ -11,15 +11,16 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum PopupType {
 
-	DANGGN(LocalDate.of(2023, 5, 18), LocalDate.of(2023, 6, 2)),
+	DANGGN(LocalDate.of(2023, 5, 18), LocalDate.of(2023, 6, 2)),			// 당근 흔들기 릴리즈 팝업 타입
+	DANGGN_UPDATE(LocalDate.of(2023, 6, 26), LocalDate.of(2023, 7, 26)), 	// 당근 흔들기 업데이트 팝업 타입 FIXME: 배포 일자에 맞춰서, 노출 일자 수정 필요
 	;
 
-	private final LocalDate startedAt;
-	private final LocalDate endedAt;
+	private final LocalDate startedDate;
+	private final LocalDate endedDate;
 
 	public static List<PopupType> findActives(LocalDate at) {
 		return Stream.of(PopupType.values())
-			.filter(popupType -> DateUtil.isInTime(popupType.startedAt, popupType.endedAt, at))
+			.filter(popupType -> DateUtil.isInTime(popupType.startedDate, popupType.endedDate, at))
 			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
## PR 타입

## 개요
- 당근 업데이트 알림 팝업 타입 추가(storage 에 key, value 추가 되어있습니다.)
<img width="218" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/480d4548-11e8-4d97-bfb8-cd15a1b5695e">
- 추후에 1등 리워드 알림(개인 별로 노출되는 기간이 다름)을 위해서 데이터들 DB에서 관리해야할 것 같은데 의견 부탁드립니다!
  예) 2회차에서 1등한 멤버는 3회차 전까지만 1등 리워드 알림 팝업이 노출되어야 한다.
<img width="243" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/9d0a4334-0c04-4cee-bfb1-c0060b463df8">

##  변경사항

