### PR TITLE
feat: 멤버 프로필 및 기수 정보 관련 API 추가

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberGeneration.java
@@ -25,6 +25,10 @@ public class MemberGeneration extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Platform platform;
 
+    private String projectTeamName;
+
+    private String role;
+
     public static MemberGeneration of(Member member, Generation generation, Platform platform){
         return new MemberGeneration(member, generation, platform);
     }
@@ -36,5 +40,13 @@ public class MemberGeneration extends BaseEntity {
         this.member = member;
         this.generation = generation;
         this.platform = platform;
+    }
+
+    public void update(
+            String projectTeamName,
+            String role
+    ) {
+        this.projectTeamName = projectTeamName;
+        this.role = role;
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberProfile.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/MemberProfile.java
@@ -1,0 +1,69 @@
+package kr.mashup.branding.domain.member;
+
+import kr.mashup.branding.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberProfile extends BaseEntity {
+
+    private LocalDate birthDate;            // 생년월일
+
+    private String job;                     // 직군
+
+    private String company;                 // 회사
+
+    private String introduction;            // 자기소개
+
+    private String residence;               // 거주기
+
+    private String socialNetworkServiceLink; // 인스타그램 링크
+
+    private String githubLink;              // 깃헙 링크
+
+    private String portfolioLink;           // 비핸스 링크
+
+    private String blogLink;                // 티스토리 링크
+
+    private String linkedInLink;            // 링크드인 링크
+
+    private Long memberId;
+
+    public static MemberProfile from(Long memberId) {
+        return new MemberProfile(memberId);
+    }
+
+    private MemberProfile(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public void update(
+            LocalDate birthDate,
+            String job,
+            String company,
+            String introduction,
+            String residence,
+            String socialNetworkServiceLink,
+            String githubLink,
+            String portfolioLink,
+            String blogLink,
+            String linkedInLink
+    ) {
+        this.birthDate = birthDate;
+        this.job = job;
+        this.company = company;
+        this.introduction = introduction;
+        this.residence = residence;
+        this.socialNetworkServiceLink = socialNetworkServiceLink;
+        this.githubLink = githubLink;
+        this.portfolioLink = portfolioLink;
+        this.blogLink = blogLink;
+        this.linkedInLink = linkedInLink;
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/scorehistory/ScoreHistory.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/scorehistory/ScoreHistory.java
@@ -14,7 +14,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -81,8 +80,6 @@ public class ScoreHistory extends BaseEntity {
         isCanceled = true;
         this.memo = memo;
     }
-
-
 
     private ScoreHistory(String type, String name, Double score, LocalDateTime date, String scheduleName,
                          Generation generation, Member member, boolean isCanceled, String memo) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepository.java
@@ -1,0 +1,11 @@
+package kr.mashup.branding.repository.member;
+
+import kr.mashup.branding.domain.member.MemberProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+
+    Optional<MemberProfile> findByMemberId(Long memberId);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberProfileService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberProfileService.java
@@ -1,0 +1,51 @@
+package kr.mashup.branding.service.member;
+
+import kr.mashup.branding.domain.member.MemberProfile;
+import kr.mashup.branding.repository.member.MemberProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberProfileService {
+
+    private final MemberProfileRepository memberProfileRepository;
+
+    public void updateOrSave(
+            Long memberId,
+            LocalDate birthDate,
+            String job,
+            String company,
+            String introduction,
+            String residence,
+            String socialNetworkServiceLink,
+            String githubLink,
+            String portfolioLink,
+            String blogLink,
+            String linkedInLink
+    ) {
+        var profile = memberProfileRepository.findByMemberId(memberId)
+                .orElseGet(() -> memberProfileRepository.save(MemberProfile.from(memberId)));
+        profile.update(
+                birthDate,
+                job,
+                company,
+                introduction,
+                residence,
+                socialNetworkServiceLink,
+                githubLink,
+                portfolioLink,
+                blogLink,
+                linkedInLink
+        );
+    }
+
+    public MemberProfile findOrSave(Long memberId) {
+        return memberProfileRepository.findByMemberId(memberId)
+                .orElseGet(() -> memberProfileRepository.save(MemberProfile.from(memberId)));
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -1,16 +1,5 @@
 package kr.mashup.branding.service.member;
 
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
@@ -34,6 +23,16 @@ import kr.mashup.branding.repository.scorehistory.ScoreHistoryRepository;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -313,5 +312,22 @@ public class MemberService {
             default:
                 throw new IllegalArgumentException();
         }
+    }
+
+    public List<MemberGeneration> findMemberGenerationByMemberId(Member member) {
+        return memberGenerationRepository.findByMember(member);
+    }
+
+    public void updateMemberGeneration(
+            Long memberGenerationId,
+            String projectTeamName,
+            String role
+    ) {
+        var memberGeneration = memberGenerationRepository.findById(memberGenerationId)
+                .orElseThrow(GenerationIntegrityFailException::new);
+        memberGeneration.update(
+                projectTeamName,
+                role
+        );
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
@@ -1,0 +1,41 @@
+package kr.mashup.branding.facade.member;
+
+import kr.mashup.branding.service.member.MemberProfileService;
+import kr.mashup.branding.ui.member.request.MemberProfileRequest;
+import kr.mashup.branding.ui.member.response.MemberProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberProfileFacadeService {
+
+    private final MemberProfileService memberProfileService;
+
+    @Transactional
+    public Boolean updateMyProfile(Long memberId, MemberProfileRequest request) {
+        memberProfileService.updateOrSave(
+                memberId,
+                request.getBirthDate(),
+                request.getJob(),
+                request.getCompany(),
+                request.getIntroduction(),
+                request.getResidence(),
+                request.getSocialNetworkServiceLink(),
+                request.getGithubLink(),
+                request.getPortfolioLink(),
+                request.getBlogLink(),
+                request.getLinkedInLink()
+        );
+
+        return true;
+    }
+
+    @Transactional
+    public MemberProfileResponse getMyProfile(Long memberId) {
+        var profile = memberProfileService.findOrSave(memberId);
+
+        return MemberProfileResponse.from(profile);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberController.java
@@ -1,17 +1,12 @@
 package kr.mashup.branding.ui.member;
 
 import io.swagger.annotations.ApiOperation;
-import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.facade.member.MemberFacadeService;
 import kr.mashup.branding.security.MemberAuth;
-import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.ApiResponse;
-import kr.mashup.branding.ui.member.request.LoginRequest;
-import kr.mashup.branding.ui.member.request.SignUpRequest;
-import kr.mashup.branding.ui.member.request.ValidInviteRequest;
-import kr.mashup.branding.ui.member.response.*;
 import kr.mashup.branding.ui.EmptyResponse;
-import kr.mashup.branding.ui.member.request.PushNotificationRequest;
+import kr.mashup.branding.ui.member.request.*;
+import kr.mashup.branding.ui.member.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
@@ -108,5 +103,4 @@ public class MemberController {
 
         return ApiResponse.success(updatePushNotificationAgreedResponse);
     }
-
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberGenerationController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberGenerationController.java
@@ -1,0 +1,44 @@
+package kr.mashup.branding.ui.member;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.member.MemberFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.member.request.MemberGenerationRequest;
+import kr.mashup.branding.ui.member.response.MemberGenerationsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("api/v1/member-generations")
+@RequiredArgsConstructor
+public class MemberGenerationController {
+
+    private final MemberFacadeService memberFacadeService;
+    @ApiOperation("멤버 기수 정보 조회")
+    @GetMapping("/my")
+    public ApiResponse<MemberGenerationsResponse> findMy(
+            @ApiIgnore MemberAuth memberAuth
+    ) {
+        final MemberGenerationsResponse response
+                = memberFacadeService.findMemberGenerationByMemberId(memberAuth.getMemberId());
+
+        return ApiResponse.success(response);
+    }
+
+    @ApiOperation("멤버 기수 정보 업데이트")
+    @PatchMapping("{id}")
+    public ApiResponse<Boolean> updateMy(
+            @ApiIgnore MemberAuth memberAuth,
+            @PathVariable Long id,
+            @Valid @RequestBody MemberGenerationRequest request
+    ) {
+        final Boolean response
+                = memberFacadeService.updateMemberGenerationById(memberAuth.getMemberId(), id, request);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
@@ -1,0 +1,43 @@
+package kr.mashup.branding.ui.member;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.member.MemberProfileFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.member.request.MemberProfileRequest;
+import kr.mashup.branding.ui.member.response.MemberProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("api/v1/member-profiles")
+@RequiredArgsConstructor
+public class MemberProfileController {
+
+    private final MemberProfileFacadeService memberProfileFacadeService;
+    @ApiOperation("멤버 프로필 조회")
+    @GetMapping("/my")
+    public ApiResponse<MemberProfileResponse> getMyProfile(
+            @ApiIgnore MemberAuth memberAuth
+    ) {
+        final MemberProfileResponse response
+                = memberProfileFacadeService.getMyProfile(memberAuth.getMemberId());
+
+        return ApiResponse.success(response);
+    }
+
+    @ApiOperation("멤버 프로필 업데이트")
+    @PatchMapping("/my")
+    public ApiResponse<Boolean> updateMyProfile(
+            @ApiIgnore MemberAuth memberAuth,
+            @Valid @RequestBody MemberProfileRequest request
+    ) {
+        final Boolean response
+                = memberProfileFacadeService.updateMyProfile(memberAuth.getMemberId(), request);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/MemberGenerationRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/MemberGenerationRequest.java
@@ -1,0 +1,11 @@
+package kr.mashup.branding.ui.member.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberGenerationRequest {
+
+    private String projectTeamName; // 프로젝트 팀명
+
+    private String role;            // 역할
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/MemberProfileRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/request/MemberProfileRequest.java
@@ -1,0 +1,29 @@
+package kr.mashup.branding.ui.member.request;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberProfileRequest {
+
+    private LocalDate birthDate;            // 생년월일
+
+    private String job;                     // 직군
+
+    private String company;                 // 회사
+
+    private String introduction;            // 자기소개
+
+    private String residence;               // 거주기
+
+    private String socialNetworkServiceLink; // 인스타그램 링크
+
+    private String githubLink;              // 깃헙 링크
+
+    private String portfolioLink;           // 비핸스 링크
+
+    private String blogLink;                // 티스토리 링크
+
+    private String linkedInLink;            // 링크드인 링크
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationResponse.java
@@ -1,0 +1,30 @@
+package kr.mashup.branding.ui.member.response;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberGenerationResponse {
+
+    private Long id;                    // 기수
+
+    private Integer number;             // 기수
+
+    private String platform;            // 플랫폼
+
+    private String projectTeamName;     // 프로젝트 팀
+
+    private String role;                // 역할
+
+    public static MemberGenerationResponse of(MemberGeneration memberGeneration) {
+        return new MemberGenerationResponse(
+                memberGeneration.getId(),
+                memberGeneration.getGeneration().getNumber(),
+                memberGeneration.getPlatform().getName(),
+                memberGeneration.getProjectTeamName(),
+                memberGeneration.getRole()
+        );
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationsResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationsResponse.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.ui.member.response;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class MemberGenerationsResponse {
+
+    private List<MemberGenerationResponse> memberGenerations;
+
+    public static MemberGenerationsResponse of(List<MemberGeneration> memberGenerations) {
+        List<MemberGenerationResponse> responses = memberGenerations.stream()
+                .map(MemberGenerationResponse::of)
+                .collect(Collectors.toList());
+        return new MemberGenerationsResponse(responses);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberProfileResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberProfileResponse.java
@@ -1,0 +1,50 @@
+package kr.mashup.branding.ui.member.response;
+
+import kr.mashup.branding.domain.member.MemberProfile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class MemberProfileResponse {
+
+    private Long memberId;
+
+    private LocalDate birthDate;            // 생년월일
+
+    private String job;                     // 직군
+
+    private String company;                 // 회사
+
+    private String introduction;            // 자기소개
+
+    private String residence;               // 거주기
+
+    private String socialNetworkServiceLink; // 인스타그램 링크
+
+    private String githubLink;              // 깃헙 링크
+
+    private String portfolioLink;           // 비핸스 링크
+
+    private String blogLink;                // 티스토리 링크
+
+    private String linkedInLink;            // 링크드인 링크
+
+    public static MemberProfileResponse from(MemberProfile memberProfile) {
+        return new MemberProfileResponse(
+                memberProfile.getMemberId(),
+                memberProfile.getBirthDate(),
+                memberProfile.getJob(),
+                memberProfile.getCompany(),
+                memberProfile.getIntroduction(),
+                memberProfile.getResidence(),
+                memberProfile.getSocialNetworkServiceLink(),
+                memberProfile.getGithubLink(),
+                memberProfile.getPortfolioLink(),
+                memberProfile.getBlogLink(),
+                memberProfile.getLinkedInLink()
+        );
+    }
+}


### PR DESCRIPTION
## PR 타입

## 개요
- 멤버 프로필 조회 및 업데이트 API 추가
<img width="1020" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/e36d581b-414d-4982-af05-d0eb8d21e7cf">

- 멤버 기수 정보 조회 및 업데이트 API 추가
<img width="819" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/eb7ef8a8-efa2-4cdf-af32-f1299574b4b8">

fyi; [피그마 링크](https://www.figma.com/file/kxgTs6r19oJz6ipQGYm83d/%EB%A7%A4%EC%89%AC%EC%97%85-%EC%95%B1?type=design&node-id=2-7&mode=design)

##  변경사항

