### PR TITLE
멤버 프로필 조회 API 추가

### DIFF
--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -1,5 +1,19 @@
 package kr.mashup.branding.facade.attendance;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.attendance.AttendanceCode;
@@ -22,17 +36,13 @@ import kr.mashup.branding.service.attendance.AttendanceCodeService;
 import kr.mashup.branding.service.attendance.AttendanceService;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.schedule.ScheduleService;
-import kr.mashup.branding.ui.attendance.response.*;
+import kr.mashup.branding.ui.attendance.response.AttendanceCheckResponse;
+import kr.mashup.branding.ui.attendance.response.AttendanceInfo;
+import kr.mashup.branding.ui.attendance.response.PersonalAttendanceResponse;
+import kr.mashup.branding.ui.attendance.response.PlatformAttendanceResponse;
+import kr.mashup.branding.ui.attendance.response.TotalAttendanceResponse;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -311,6 +321,7 @@ public class AttendanceFacadeService {
                 members.stream()
                         .map(member -> PlatformAttendanceResponse.MemberInfo.of(
                                 member.getName(),
+                                member.getId(),
                                 getAttendanceInfoByMember(
                                         member,
                                         schedule.getEventList(),

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
@@ -1,17 +1,21 @@
 package kr.mashup.branding.facade.member;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.service.member.MemberProfileService;
+import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.member.request.MemberProfileRequest;
 import kr.mashup.branding.ui.member.response.MemberProfileResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberProfileFacadeService {
 
     private final MemberProfileService memberProfileService;
+    private final MemberService memberService;
 
     @Transactional
     public Boolean updateMyProfile(Long memberId, MemberProfileRequest request) {
@@ -34,8 +38,11 @@ public class MemberProfileFacadeService {
 
     @Transactional
     public MemberProfileResponse getMyProfile(Long memberId) {
-        var profile = memberProfileService.findOrSave(memberId);
+        Member member = memberService.findMemberById(memberId);
 
-        return MemberProfileResponse.from(profile);
+        var profile = memberProfileService.findOrSave(memberId);
+        var generations = memberService.findMemberGenerationByMemberId(member);
+
+        return MemberProfileResponse.from(profile, generations);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/scorehistory/ScoreHistoryFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/scorehistory/ScoreHistoryFacadeService.java
@@ -1,19 +1,20 @@
 package kr.mashup.branding.facade.scorehistory;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.scorehistory.ScoreHistory;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.scorehistory.ScoreHistoryService;
 import kr.mashup.branding.ui.scorehistory.response.ScoreHistoryResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/attendance/response/PlatformAttendanceResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/attendance/response/PlatformAttendanceResponse.java
@@ -1,11 +1,11 @@
 package kr.mashup.branding.ui.attendance.response;
 
+import java.util.List;
+
 import io.swagger.annotations.ApiModelProperty;
 import kr.mashup.branding.domain.member.Platform;
 import lombok.Getter;
 import lombok.Value;
-
-import java.util.List;
 
 @Getter
 @Value(staticConstructor = "of")
@@ -20,6 +20,8 @@ public class PlatformAttendanceResponse {
     public static class MemberInfo {
         @ApiModelProperty(required = true)
         String name;
+        @ApiModelProperty(required = true)
+        Long memberId;
         @ApiModelProperty(required = true, notes = "출석 정보가 없을 땐 빈 리스트")
         List<AttendanceInfo> attendanceInfos;
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberGenerationController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberGenerationController.java
@@ -1,5 +1,14 @@
 package kr.mashup.branding.ui.member;
 
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.member.MemberFacadeService;
 import kr.mashup.branding.security.MemberAuth;
@@ -7,10 +16,7 @@ import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.member.request.MemberGenerationRequest;
 import kr.mashup.branding.ui.member.response.MemberGenerationsResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.validation.Valid;
 
 @RestController
 @RequestMapping("api/v1/member-generations")
@@ -18,7 +24,8 @@ import javax.validation.Valid;
 public class MemberGenerationController {
 
     private final MemberFacadeService memberFacadeService;
-    @ApiOperation("멤버 기수 정보 조회")
+
+    @ApiOperation("나의 기수 정보 조회")
     @GetMapping("/my")
     public ApiResponse<MemberGenerationsResponse> findMy(
             @ApiIgnore MemberAuth memberAuth

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
@@ -1,5 +1,14 @@
 package kr.mashup.branding.ui.member;
 
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.member.MemberProfileFacadeService;
 import kr.mashup.branding.security.MemberAuth;
@@ -7,10 +16,7 @@ import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.member.request.MemberProfileRequest;
 import kr.mashup.branding.ui.member.response.MemberProfileResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.validation.Valid;
 
 @RestController
 @RequestMapping("api/v1/member-profiles")
@@ -18,7 +24,8 @@ import javax.validation.Valid;
 public class MemberProfileController {
 
     private final MemberProfileFacadeService memberProfileFacadeService;
-    @ApiOperation("멤버 프로필 조회")
+
+    @ApiOperation("나의 프로필 조회")
     @GetMapping("/my")
     public ApiResponse<MemberProfileResponse> getMyProfile(
             @ApiIgnore MemberAuth memberAuth
@@ -29,7 +36,7 @@ public class MemberProfileController {
         return ApiResponse.success(response);
     }
 
-    @ApiOperation("멤버 프로필 업데이트")
+    @ApiOperation("나의 프로필 업데이트")
     @PatchMapping("/my")
     public ApiResponse<Boolean> updateMyProfile(
             @ApiIgnore MemberAuth memberAuth,
@@ -37,6 +44,15 @@ public class MemberProfileController {
     ) {
         final Boolean response
                 = memberProfileFacadeService.updateMyProfile(memberAuth.getMemberId(), request);
+
+        return ApiResponse.success(response);
+    }
+
+    @ApiOperation("멤버 프로필 조회")
+    @GetMapping("/{memberId}")
+    public ApiResponse<MemberProfileResponse> getMemberProfile(@PathVariable Long memberId) {
+        final MemberProfileResponse response
+            = memberProfileFacadeService.getMyProfile(memberId);
 
         return ApiResponse.success(response);
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberProfileResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberProfileResponse.java
@@ -1,10 +1,13 @@
 package kr.mashup.branding.ui.member.response;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.MemberProfile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
@@ -32,7 +35,9 @@ public class MemberProfileResponse {
 
     private String linkedInLink;            // 링크드인 링크
 
-    public static MemberProfileResponse from(MemberProfile memberProfile) {
+    private List<MemberGenerationResponse> memberGenerations;
+
+    public static MemberProfileResponse from(MemberProfile memberProfile, List<MemberGeneration> memberGenerations) {
         return new MemberProfileResponse(
                 memberProfile.getMemberId(),
                 memberProfile.getBirthDate(),
@@ -44,7 +49,10 @@ public class MemberProfileResponse {
                 memberProfile.getGithubLink(),
                 memberProfile.getPortfolioLink(),
                 memberProfile.getBlogLink(),
-                memberProfile.getLinkedInLink()
+                memberProfile.getLinkedInLink(),
+                memberGenerations.stream()
+                    .map(MemberGenerationResponse::of)
+                    .collect(Collectors.toList())
         );
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/scorehistory/ScoreHistoryController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/scorehistory/ScoreHistoryController.java
@@ -1,5 +1,12 @@
 package kr.mashup.branding.ui.scorehistory;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.scorehistory.ScoreHistoryFacadeService;
 import kr.mashup.branding.security.MemberAuth;
@@ -7,12 +14,7 @@ import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.scorehistory.response.ScoreHistoriesResponse;
 import kr.mashup.branding.ui.scorehistory.response.ScoreHistoryResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/score-history")
@@ -29,5 +31,17 @@ public class ScoreHistoryController {
                 = scoreHistoryFacadeService.getScoreHistory(memberAuth.getMemberId());
 
         return ApiResponse.success(ScoreHistoriesResponse.of(scoreHistoryResponses));
+    }
+
+    @ApiOperation("멤버 점수")
+    @GetMapping("/{memberId}")
+    public ApiResponse<ScoreHistoryResponse> getScore(@PathVariable Long memberId) {
+
+        final ScoreHistoryResponse scoreHistoryResponses
+            = scoreHistoryFacadeService.getScoreHistory(memberId)
+            .stream().findFirst()
+            .orElse(null);
+
+        return ApiResponse.success(scoreHistoryResponses);
     }
 }


### PR DESCRIPTION
## PR 타입

## 개요
<img width="1035" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/4f7ec6fe-99e1-4330-9bfd-e658f03b4a24">

- 출결 조회 API 응답값에 멤버 프로필 조회에 필요한 멤버 아이디 추가
- 멤버 프로필 조회 API 추가
- 멤버 점수 조회 API 추가
 
##  변경사항

