### PR TITLE
스케줄에 위치 정보 추가

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -64,7 +64,7 @@ public class ScheduleFacadeService {
         final DateRange dateRange
                 = DateRange.of(request.getStartedAt(), request.getEndedAt());
         final Schedule schedule
-                = scheduleService.create(generation, ScheduleCreateDto.of(request.getName(), dateRange));
+                = scheduleService.create(generation, ScheduleCreateDto.of(request.getName(), dateRange, request.getLatitude(), request.getLongitude()));
 
         doUpdateSchedule(schedule, request);
 
@@ -102,7 +102,7 @@ public class ScheduleFacadeService {
         final Generation generation
                 = generationService.getByNumberOrThrow(request.getGenerationNumber());
 
-        ScheduleCreateDto scheduleCreateDto = ScheduleCreateDto.of(request.getName(), DateRange.of(request.getStartedAt(), request.getEndedAt()));
+        ScheduleCreateDto scheduleCreateDto = ScheduleCreateDto.of(request.getName(), DateRange.of(request.getStartedAt(), request.getEndedAt()), request.getLatitude(), request.getLongitude());
 
         schedule = scheduleService.updateSchedule(schedule, generation, scheduleCreateDto);
 

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
@@ -23,6 +23,12 @@ public class ScheduleCreateRequest {
     @NotNull
     private LocalDateTime endedAt;
 
+    @NotNull
+    private Double latitude;
+
+    @NotNull
+    private Double longitude;
+
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;
 

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
@@ -25,6 +25,12 @@ public class ScheduleUpdateRequest {
     @NotNull
     private LocalDateTime endedAt;
 
+    @NotNull
+    private Double latitude;
+
+    @NotNull
+    private Double longitude;
+
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;
 }

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -23,6 +23,10 @@ public class ScheduleResponse {
 
     Integer generationNumber;
 
+    Double latitude;
+
+    Double longitude;
+
     List<EventResponse> eventList;
 
     ScheduleStatus status;
@@ -40,6 +44,8 @@ public class ScheduleResponse {
             schedule.getStartedAt(),
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),
+            schedule.getLocation() == null ? null : schedule.getLocation().getLatitude(),
+            schedule.getLocation() == null ? null : schedule.getLocation().getLongitude(),
             schedule.getEventList()
                 .stream()
                 .map(EventResponse::from)

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Location.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Location.java
@@ -3,7 +3,9 @@ package kr.mashup.branding.domain.schedule;
 import javax.persistence.Embeddable;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Embeddable
 @Getter
 public class Location {
@@ -11,6 +13,11 @@ public class Location {
     private Double longitude;
 
     private static final double EARTH_RADIUS = 6371000; // 지구 반지름 (미터)
+
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
     /**
      * Haversine 공식을 사용하여 두 지점 간의 거리 계산

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -70,11 +70,11 @@ public class Schedule extends BaseEntity {
     @LastModifiedBy
     private String updatedBy;
 
-    public static Schedule of(Generation generation, String name, DateRange dateRange) {
-        return new Schedule(generation, name, dateRange);
+    public static Schedule of(Generation generation, String name, DateRange dateRange, Double latitude, Double longitude) {
+        return new Schedule(generation, name, dateRange, new Location(latitude, longitude));
     }
 
-    public Schedule(Generation generation, String name, DateRange dateRange) {
+    public Schedule(Generation generation, String name, DateRange dateRange, Location location) {
         checkStartBeforeOrEqualEnd(dateRange.getStart(), dateRange.getEnd());
 
         this.generation = generation;
@@ -83,6 +83,7 @@ public class Schedule extends BaseEntity {
         this.endedAt = dateRange.getEnd();
         this.status = ScheduleStatus.ADMIN_ONLY;
         this.isCounted = false; // 기본값은 false 로 설정(배치가 수행되지 않음)
+        this.location = location;
     }
 
     public void publishSchedule(){
@@ -126,6 +127,10 @@ public class Schedule extends BaseEntity {
         checkStartBeforeOrEqualEnd(startDate, endDate);
         this.startedAt = startDate;
         this.endedAt = endDate;
+    }
+
+    public void changeLocation(Double latitude, Double longitude) {
+        this.location = new Location(latitude, longitude);
     }
 
     public void changeStartDate(LocalDateTime newStartDate) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleCreateDto.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleCreateDto.java
@@ -9,4 +9,6 @@ import lombok.Value;
 public class ScheduleCreateDto {
     String name;
     DateRange dateRange;
+    Double latitude;
+    Double longitude;
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -28,7 +28,7 @@ public class ScheduleService {
     private final AttendanceCodeRepository attendanceCodeRepository;
 
     public Schedule create(Generation generation, ScheduleCreateDto dto) {
-        Schedule schedule = Schedule.of(generation, dto.getName(), dto.getDateRange());
+        Schedule schedule = Schedule.of(generation, dto.getName(), dto.getDateRange(), dto.getLatitude(), dto.getLongitude());
         return scheduleRepository.save(schedule);
     }
 
@@ -109,6 +109,7 @@ public class ScheduleService {
         schedule.changeName(scheduleCreateDto.getName());
         schedule.changeGeneration(generation);
         schedule.changeDate(scheduleCreateDto.getDateRange().getStart(), scheduleCreateDto.getDateRange().getEnd());
+        schedule.changeLocation(scheduleCreateDto.getLatitude(), scheduleCreateDto.getLongitude());
 
         return schedule;
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -24,6 +24,10 @@ public class ScheduleResponse {
 
     Integer generationNumber;
 
+    Double latitude;
+
+    Double longitude;
+
     List<EventResponse> eventList;
 
     public static ScheduleResponse from(Schedule schedule, Integer dateCount) {
@@ -34,6 +38,8 @@ public class ScheduleResponse {
             schedule.getStartedAt(),
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),
+            schedule.getLocation() == null ? null : schedule.getLocation().getLatitude(),
+            schedule.getLocation() == null ? null : schedule.getLocation().getLongitude(),
             schedule.getEventList()
                 .stream()
                 .map(EventResponse::from)


### PR DESCRIPTION
## PR 타입

## 개요
- 어드민 스케줄 생성/수정에 위치 정보 추가
- 어드민/멤버 스케줄 조회에 위치 정보 추가

##  변경사항
- 어드민/멤버 `ScheduleResponse`에 위도 경도 추가
- 어드민 `ScheduleUpdateRequest`에 위도 경도 추가
- 어드민 `ScheduleCreateRequest`에 위도 경도 추가

