### PR TITLE
Feature/schedule type

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -82,7 +82,7 @@ public class ScheduleFacadeService {
         scheduleService.publishSchedule(schedule);
 
         pushNotiEventPublisher.publishPushNotiSendEvent(
-            new SeminarUpdatedVo(memberService.getPushNotiTargetableMembersByScheduleType(schedule.getScheduleType()), schedule.getScheduleType())
+            new SeminarUpdatedVo(memberService.getPushNotiTargetableMembersBySchedule(schedule), schedule.getScheduleType())
         );
     }
 

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -2,10 +2,7 @@ package kr.mashup.branding.facade.schedule;
 
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.pushnoti.vo.SeminarUpdatedVo;
-import kr.mashup.branding.domain.schedule.ContentsCreateDto;
-import kr.mashup.branding.domain.schedule.Event;
-import kr.mashup.branding.domain.schedule.Schedule;
-import kr.mashup.branding.domain.schedule.ScheduleCreateDto;
+import kr.mashup.branding.domain.schedule.*;
 import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
 import kr.mashup.branding.service.generation.GenerationService;
 import kr.mashup.branding.service.member.MemberService;
@@ -37,12 +34,12 @@ public class ScheduleFacadeService {
     private final PushNotiEventPublisher pushNotiEventPublisher;
     private final MemberService memberService;
 
-    public Page<ScheduleResponse> getSchedules(Integer generationNumber, String searchWord, Pageable pageable) {
+    public Page<ScheduleResponse> getSchedules(Integer generationNumber, String searchWord, ScheduleType scheduleType, Pageable pageable) {
 
         final Generation generation
                 = generationService.getByNumberOrThrow(generationNumber);
 
-        final Page<Schedule> schedules = scheduleService.getByGeneration(generation, searchWord, null, pageable);
+        final Page<Schedule> schedules = scheduleService.getByGeneration(generation, searchWord, scheduleType, null, pageable);
         final List<ScheduleResponse> scheduleResponses = schedules
                 .stream()
                 .map(ScheduleResponse::from)

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -64,7 +64,7 @@ public class ScheduleFacadeService {
         final DateRange dateRange
                 = DateRange.of(request.getStartedAt(), request.getEndedAt());
         final ScheduleCreateDto createDto =
-                ScheduleCreateDto.of(request.getName(), dateRange, request.getLatitude(), request.getLongitude(), request.getAddress(), request.getPlaceName());
+                ScheduleCreateDto.of(request.getName(), dateRange, request.getLatitude(), request.getLongitude(), request.getAddress(), request.getPlaceName(), request.getScheduleType());
         final Schedule schedule
                 = scheduleService.create(generation, createDto);
 
@@ -106,7 +106,7 @@ public class ScheduleFacadeService {
 
         final DateRange dateRange = DateRange.of(request.getStartedAt(), request.getEndedAt());
         final ScheduleCreateDto scheduleCreateDto =
-                ScheduleCreateDto.of(request.getName(), dateRange, request.getLatitude(), request.getLongitude(), request.getAddress(), request.getPlaceName());
+                ScheduleCreateDto.of(request.getName(), dateRange, request.getLatitude(), request.getLongitude(), request.getAddress(), request.getPlaceName(), request.getScheduleType());
 
         schedule = scheduleService.updateSchedule(schedule, generation, scheduleCreateDto);
 

--- a/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -82,7 +82,7 @@ public class ScheduleFacadeService {
         scheduleService.publishSchedule(schedule);
 
         pushNotiEventPublisher.publishPushNotiSendEvent(
-            new SeminarUpdatedVo(memberService.getAllPushNotiTargetableMembers())
+            new SeminarUpdatedVo(memberService.getPushNotiTargetableMembersByScheduleType(schedule.getScheduleType()), schedule.getScheduleType())
         );
     }
 

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.ui.schedule;
 import javax.validation.Valid;
 
 import kr.mashup.branding.EmptyResponse;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import kr.mashup.branding.ui.schedule.request.ScheduleUpdateRequest;
 import kr.mashup.branding.ui.schedule.response.QrCodeResponse;
 import kr.mashup.branding.ui.schedule.request.QrCodeGenerateRequest;
@@ -32,12 +33,12 @@ public class ScheduleController {
     @ApiOperation("스케줄 조회")
     @GetMapping
     public ApiResponse<List<ScheduleResponse>> getSchedules(
-            @RequestParam(defaultValue = "13", required = false) Integer generationNumber,
+            @RequestParam(defaultValue = "14", required = false) Integer generationNumber,
+            @RequestParam(defaultValue = "ALL", required = false) ScheduleType scheduleType,
             @RequestParam(required = false) String searchWord,
             @PageableDefault Pageable pageable
     ) {
-        final Page<ScheduleResponse> responses
-                = scheduleFacadeService.getSchedules(generationNumber, searchWord, pageable);
+        final Page<ScheduleResponse> responses = scheduleFacadeService.getSchedules(generationNumber, searchWord, scheduleType, pageable);
 
         return ApiResponse.success(responses);
     }

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
@@ -31,7 +31,7 @@ public class ScheduleCreateRequest {
 
     private String placeName;
 
-    private ScheduleType scheduleType;
+    private ScheduleType scheduleType = ScheduleType.ALL;
 
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleCreateRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.*;
 
 @Getter
@@ -29,6 +30,8 @@ public class ScheduleCreateRequest {
     private String address;
 
     private String placeName;
+
+    private ScheduleType scheduleType;
 
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
@@ -34,7 +34,7 @@ public class ScheduleUpdateRequest {
 
     private String placeName;
 
-    private ScheduleType scheduleType;
+    private ScheduleType scheduleType = ScheduleType.ALL;
 
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/request/ScheduleUpdateRequest.java
@@ -1,5 +1,6 @@
 package kr.mashup.branding.ui.schedule.request;
 
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -32,6 +33,8 @@ public class ScheduleUpdateRequest {
     private String address;
 
     private String placeName;
+
+    private ScheduleType scheduleType;
 
     @NotEmpty
     private List<EventCreateRequest> eventsCreateRequests;

--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import kr.mashup.branding.domain.schedule.Location;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.Getter;
 import lombok.Value;
 
@@ -26,6 +27,8 @@ public class ScheduleResponse {
 
     Location location;
 
+    ScheduleType scheduleType;
+
     List<EventResponse> eventList;
 
     ScheduleStatus status;
@@ -44,6 +47,7 @@ public class ScheduleResponse {
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),
             schedule.getLocation() == null ? null : schedule.getLocation(),
+            schedule.getScheduleType(),
             schedule.getEventList()
                 .stream()
                 .map(EventResponse::from)

--- a/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
+++ b/mashup-batch/src/main/java/kr/mashup/branding/facade/ScoreHistoryFacadeService.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.facade;
 import kr.mashup.branding.domain.attendance.Attendance;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import kr.mashup.branding.domain.scorehistory.ScoreHistory;
 import kr.mashup.branding.domain.scorehistory.ScoreType;
 import kr.mashup.branding.service.attendance.AttendanceService;
@@ -32,7 +33,7 @@ public class ScoreHistoryFacadeService {
      */
     @Transactional
     public List<Member> create() {
-        List<Schedule> schedules = scheduleService.findEndedScheduleByIsCounted(false);
+        List<Schedule> schedules = scheduleService.findEndedScheduleByIsCountedAndScheduleType(false, ScheduleType.ALL);
         Set<Member> updatedMember = new HashSet<>();
 
         schedules.forEach(schedule -> {
@@ -90,7 +91,7 @@ public class ScoreHistoryFacadeService {
      * @param scheduleStartDate
      */
     public void delete(LocalDate scheduleStartDate) {
-        Schedule schedule = scheduleService.findByStartDate(scheduleStartDate);
+        Schedule schedule = scheduleService.findScheduleByStartDateAndScheduleType(scheduleStartDate, ScheduleType.ALL);
         List<ScoreHistory> scoreHistories = scoreHistoryService.findAttendanceScoreByDate(scheduleStartDate);
 
         scoreHistoryService.deleteAll(scoreHistories);

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Platform.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Platform.java
@@ -3,7 +3,6 @@ package kr.mashup.branding.domain.member;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
-import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -29,15 +28,5 @@ public enum Platform {
             log.info("platform type conversion error : {}", e.getMessage());
             throw new BadRequestException(ResultCode.INVALID_PLATFORM_NAME);
         }
-    }
-
-    public Boolean checkAvailabilityByScheduleType(ScheduleType scheduleType) {
-        if (scheduleType == ScheduleType.ALL) return true;
-        if (scheduleType == ScheduleType.SPRING && this == SPRING) return true;
-        if (scheduleType == ScheduleType.IOS && this == IOS) return true;
-        if (scheduleType == ScheduleType.DESIGN && this == DESIGN) return true;
-        if (scheduleType == ScheduleType.WEB && this == WEB) return true;
-        if (scheduleType == ScheduleType.NODE && this == NODE) return true;
-        return false;
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Platform.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/member/Platform.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.domain.member;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -28,5 +29,15 @@ public enum Platform {
             log.info("platform type conversion error : {}", e.getMessage());
             throw new BadRequestException(ResultCode.INVALID_PLATFORM_NAME);
         }
+    }
+
+    public Boolean checkAvailabilityByScheduleType(ScheduleType scheduleType) {
+        if (scheduleType == ScheduleType.ALL) return true;
+        if (scheduleType == ScheduleType.SPRING && this == SPRING) return true;
+        if (scheduleType == ScheduleType.IOS && this == IOS) return true;
+        if (scheduleType == ScheduleType.DESIGN && this == DESIGN) return true;
+        if (scheduleType == ScheduleType.WEB && this == WEB) return true;
+        if (scheduleType == ScheduleType.NODE && this == NODE) return true;
+        return false;
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarUpdatedVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarUpdatedVo.java
@@ -6,13 +6,26 @@ import java.util.Map;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.pushnoti.DataKeyType;
 import kr.mashup.branding.domain.pushnoti.LinkType;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 
 public class SeminarUpdatedVo extends PushNotiSendVo {
     private static final String title = "세미나 알림";
     private static final String body = "세미나 정보가 업데이트 되었어요.";
     private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
 
-    public SeminarUpdatedVo(List<Member> members) {
-        super(members, title, body, dataMap);
+    public SeminarUpdatedVo(List<Member> members, ScheduleType scheduleType) {
+        super(members, title, generatePushBody(body, scheduleType), dataMap);
+    }
+
+    private static String generatePushBody(String body, ScheduleType scheduleType) {
+        return switch (scheduleType) {
+            case ALL -> "전체 " + body;
+            case IOS -> "iOS팀 " + body;
+            case WEB -> "웹팀 " + body;
+            case NODE -> "노드팀 " + body;
+            case DESIGN -> "디자인팀 " + body;
+            case SPRING -> "스프링팀 " + body;
+            case ANDROID -> "안드로이드팀 " + body;
+        };
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarUpdatedVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarUpdatedVo.java
@@ -18,14 +18,22 @@ public class SeminarUpdatedVo extends PushNotiSendVo {
     }
 
     private static String generatePushBody(String body, ScheduleType scheduleType) {
-        return switch (scheduleType) {
-            case ALL -> "전체 " + body;
-            case IOS -> "iOS팀 " + body;
-            case WEB -> "웹팀 " + body;
-            case NODE -> "노드팀 " + body;
-            case DESIGN -> "디자인팀 " + body;
-            case SPRING -> "스프링팀 " + body;
-            case ANDROID -> "안드로이드팀 " + body;
-        };
+        switch (scheduleType) {
+            case ALL:
+                return "전체 " + body;
+            case IOS:
+                return "iOS팀 " + body;
+            case WEB:
+                return "웹팀 " + body;
+            case NODE:
+                return "노드팀 " + body;
+            case DESIGN:
+                return "디자인팀 " + body;
+            case SPRING:
+                return "스프링팀 " + body;
+            case ANDROID:
+                return "안드로이드팀 " + body;
+        }
+        throw new IllegalStateException();
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -73,11 +73,11 @@ public class Schedule extends BaseEntity {
     @LastModifiedBy
     private String updatedBy;
 
-    public static Schedule of(Generation generation, String name, DateRange dateRange, Location location) {
-        return new Schedule(generation, name, dateRange, location);
+    public static Schedule of(Generation generation, String name, DateRange dateRange, Location location, ScheduleType scheduleType) {
+        return new Schedule(generation, name, dateRange, location, scheduleType);
     }
 
-    public Schedule(Generation generation, String name, DateRange dateRange, Location location) {
+    public Schedule(Generation generation, String name, DateRange dateRange, Location location, ScheduleType scheduleType) {
         checkStartBeforeOrEqualEnd(dateRange.getStart(), dateRange.getEnd());
 
         this.generation = generation;
@@ -87,6 +87,7 @@ public class Schedule extends BaseEntity {
         this.status = ScheduleStatus.ADMIN_ONLY;
         this.isCounted = false; // 기본값은 false 로 설정(배치가 수행되지 않음)
         this.location = location;
+        this.scheduleType = scheduleType;
     }
 
     public void publishSchedule(){
@@ -144,6 +145,10 @@ public class Schedule extends BaseEntity {
     public void changeEndDate(LocalDateTime newEndDate) {
         checkStartBeforeOrEqualEnd(startedAt, newEndDate);
         this.endedAt = newEndDate;
+    }
+
+    public void changeScheduleType(ScheduleType scheduleType) {
+        this.scheduleType = scheduleType;
     }
 
     private void checkStartBeforeOrEqualEnd(LocalDateTime startedAt, LocalDateTime endedAt) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -64,6 +64,9 @@ public class Schedule extends BaseEntity {
     @Embedded
     private Location location;
 
+    @Enumerated(EnumType.STRING)
+    private ScheduleType scheduleType;
+
     @CreatedBy
     private String createdBy;
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -3,7 +3,6 @@ package kr.mashup.branding.domain.schedule;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
@@ -91,7 +90,7 @@ public class Schedule extends BaseEntity {
         this.status = ScheduleStatus.ADMIN_ONLY;
         this.isCounted = false; // 기본값은 false 로 설정(배치가 수행되지 않음)
         this.location = location;
-        this.scheduleType = Objects.requireNonNullElse(scheduleType, ALL);
+        this.scheduleType = scheduleType;
     }
 
     public void publishSchedule(){
@@ -152,7 +151,7 @@ public class Schedule extends BaseEntity {
     }
 
     public void changeScheduleType(ScheduleType scheduleType) {
-        this.scheduleType = Objects.requireNonNullElse(scheduleType, ALL);
+        this.scheduleType = scheduleType;
     }
 
     private void checkStartBeforeOrEqualEnd(LocalDateTime startedAt, LocalDateTime endedAt) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -17,6 +17,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.validation.constraints.NotNull;
 
+import kr.mashup.branding.domain.member.Platform;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.util.Assert;
@@ -29,6 +30,8 @@ import kr.mashup.branding.util.DateUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static kr.mashup.branding.domain.schedule.ScheduleType.*;
 
 @Entity
 @Getter
@@ -88,7 +91,7 @@ public class Schedule extends BaseEntity {
         this.status = ScheduleStatus.ADMIN_ONLY;
         this.isCounted = false; // 기본값은 false 로 설정(배치가 수행되지 않음)
         this.location = location;
-        this.scheduleType = Objects.requireNonNullElse(scheduleType, ScheduleType.ALL);
+        this.scheduleType = Objects.requireNonNullElse(scheduleType, ALL);
     }
 
     public void publishSchedule(){
@@ -149,7 +152,7 @@ public class Schedule extends BaseEntity {
     }
 
     public void changeScheduleType(ScheduleType scheduleType) {
-        this.scheduleType = Objects.requireNonNullElse(scheduleType, ScheduleType.ALL);
+        this.scheduleType = Objects.requireNonNullElse(scheduleType, ALL);
     }
 
     private void checkStartBeforeOrEqualEnd(LocalDateTime startedAt, LocalDateTime endedAt) {
@@ -166,5 +169,15 @@ public class Schedule extends BaseEntity {
 
     public Boolean isOnline() {
         return this.location == null || this.location.getLatitude() == null || this.location.getLongitude() == null;
+    }
+
+    public Boolean checkAvailabilityByPlatform(Platform platform) {
+        if (scheduleType == ALL) return true;
+        if (scheduleType == SPRING && platform == Platform.SPRING) return true;
+        if (scheduleType == IOS && platform == Platform.IOS) return true;
+        if (scheduleType == DESIGN && platform == Platform.DESIGN) return true;
+        if (scheduleType == WEB && platform == Platform.WEB) return true;
+        if (scheduleType == NODE && platform == Platform.NODE) return true;
+        return false;
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.domain.schedule;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
@@ -87,7 +88,7 @@ public class Schedule extends BaseEntity {
         this.status = ScheduleStatus.ADMIN_ONLY;
         this.isCounted = false; // 기본값은 false 로 설정(배치가 수행되지 않음)
         this.location = location;
-        this.scheduleType = scheduleType;
+        this.scheduleType = Objects.requireNonNullElse(scheduleType, ScheduleType.ALL);
     }
 
     public void publishSchedule(){
@@ -148,7 +149,7 @@ public class Schedule extends BaseEntity {
     }
 
     public void changeScheduleType(ScheduleType scheduleType) {
-        this.scheduleType = scheduleType;
+        this.scheduleType = Objects.requireNonNullElse(scheduleType, ScheduleType.ALL);
     }
 
     private void checkStartBeforeOrEqualEnd(LocalDateTime startedAt, LocalDateTime endedAt) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleCreateDto.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleCreateDto.java
@@ -13,4 +13,5 @@ public class ScheduleCreateDto {
     Double longitude;
     String address;
     String placeName;
+    ScheduleType scheduleType;
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleType.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/ScheduleType.java
@@ -1,0 +1,5 @@
+package kr.mashup.branding.domain.schedule;
+
+public enum ScheduleType {
+    ALL, DESIGN, SPRING, IOS, ANDROID, WEB, NODE
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.repository.schedule;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,7 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, ScheduleRepositoryCustom {
 
-    List<Schedule> findAllByIsCountedAndEndedAtIsBefore(Boolean isCounted, LocalDateTime at);
+    List<Schedule> findAllByIsCountedAndEndedAtIsBeforeAndScheduleType(Boolean isCounted, LocalDateTime at, ScheduleType scheduleType);
 
     Optional<Schedule> findByIdAndStatus(Long id, ScheduleStatus status);
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
@@ -3,6 +3,7 @@ package kr.mashup.branding.repository.schedule;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,5 +14,5 @@ public interface ScheduleRepositoryCustom {
 
     Page<Schedule> retrieveByGeneration(Generation generation, String searchWord, ScheduleStatus status, Pageable pageable);
 
-    Optional<Schedule> retrieveByStartDate(LocalDate startDate);
+    Optional<Schedule> retrieveByStartDateAndScheduleType(LocalDate startDate, ScheduleType scheduleType);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustom.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface ScheduleRepositoryCustom {
 
-    Page<Schedule> retrieveByGeneration(Generation generation, String searchWord, ScheduleStatus status, Pageable pageable);
+    Page<Schedule> retrieveByGenerationAndScheduleType(Generation generation, String searchWord, ScheduleType scheduleType, ScheduleStatus status, Pageable pageable);
 
     Optional<Schedule> retrieveByStartDateAndScheduleType(LocalDate startDate, ScheduleType scheduleType);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import kr.mashup.branding.util.QueryUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -72,12 +73,15 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
         return schedule.status.eq(status);
     }
 
-    public Optional<Schedule> retrieveByStartDate(LocalDate startDate) {
+    public Optional<Schedule> retrieveByStartDateAndScheduleType(LocalDate startDate, ScheduleType scheduleType) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(schedule)
-                .where(schedule.startedAt.between(
+                .where(
+                    schedule.startedAt.between(
                         startDate.atStartOfDay(),
-                        LocalDateTime.of(startDate, LocalTime.MAX).withNano(0)))
+                        LocalDateTime.of(startDate, LocalTime.MAX).withNano(0))
+                        .and(schedule.scheduleType.eq(scheduleType))
+                )
                 .fetchOne());
 
     }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepositoryCustomImpl.java
@@ -32,13 +32,14 @@ public class ScheduleRepositoryCustomImpl implements ScheduleRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Schedule> retrieveByGeneration(Generation _generation, String searchWord, ScheduleStatus status, Pageable pageable) {
+    public Page<Schedule> retrieveByGenerationAndScheduleType(Generation _generation, String searchWord, ScheduleType scheduleType, ScheduleStatus status, Pageable pageable) {
         final Sort sort = pageable.getSortOr(Sort.by(Sort.Direction.ASC, "startedAt"));
 
         final QueryResults<Schedule> queryResults = queryFactory
                 .selectFrom(schedule)
                 .join(schedule.generation, generation).fetchJoin()
                 .where(generation.eq(_generation)
+                        .and(schedule.scheduleType.eq(scheduleType))
                         .and(eqStatus(status))
                         .and(isContainSearchWord(searchWord)))
                 .orderBy(getOrderSpecifier(sort))

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import kr.mashup.branding.domain.schedule.ScheduleType;
+import kr.mashup.branding.domain.schedule.Schedule;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -203,20 +203,12 @@ public class MemberService {
             .collect(Collectors.toList());
     }
 
-    public List<Member> getPushNotiTargetableMembersByScheduleType(ScheduleType scheduleType) {
+    public List<Member> getPushNotiTargetableMembersBySchedule(Schedule schedule) {
         LocalDate now = LocalDate.now();
         return memberRepository.findAllByCurrentGenerationAt(now).stream()
             .filter(Member::getNewsPushNotificationAgreed)
-            .filter(member -> isAvailableByScheduleTypeAndLocalDate(member, scheduleType, now))
+            .filter(member -> schedule.checkAvailabilityByPlatform(getLatestPlatform(member)))
             .collect(Collectors.toList());
-    }
-
-    private Boolean isAvailableByScheduleTypeAndLocalDate(Member member, ScheduleType scheduleType, LocalDate now) {
-        List<MemberGeneration> memberGenerations = member.getMemberGenerations();
-        return !memberGenerations.stream().filter(memberGeneration ->
-            memberGeneration.getGeneration().isInProgress(now) &&
-                memberGeneration.getPlatform().checkAvailabilityByScheduleType(scheduleType)
-        ).toList().isEmpty();
     }
 
     public List<Member> getPushNotiTargetableMembers(List<Long> memberIds) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -10,7 +10,6 @@ import kr.mashup.branding.repository.attendancecode.AttendanceCodeRepository;
 import kr.mashup.branding.repository.schedule.ScheduleRepository;
 import kr.mashup.branding.util.DateRange;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.exception.DataException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -152,12 +151,12 @@ public class ScheduleService {
     }
 
 
-    public List<Schedule> findEndedScheduleByIsCounted(boolean isCounted) {
-        return scheduleRepository.findAllByIsCountedAndEndedAtIsBefore(isCounted, LocalDateTime.now());
+    public List<Schedule> findEndedScheduleByIsCountedAndScheduleType(boolean isCounted, ScheduleType scheduleType) {
+        return scheduleRepository.findAllByIsCountedAndEndedAtIsBeforeAndScheduleType(isCounted, LocalDateTime.now(), scheduleType);
     }
 
-    public Schedule findByStartDate(LocalDate startDate) {
-        return scheduleRepository.retrieveByStartDate(startDate)
+    public Schedule findScheduleByStartDateAndScheduleType(LocalDate startDate, ScheduleType scheduleType) {
+        return scheduleRepository.retrieveByStartDateAndScheduleType(startDate, scheduleType)
                 .orElseThrow(ScheduleNotFoundException::new);
     }
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -62,9 +62,9 @@ public class ScheduleService {
         return scheduleRepository.findByGenerationAndStatusOrderByStartedAtAsc(generation, status);
     }
 
-    public Page<Schedule> getByGeneration(Generation generation, String searchWord, ScheduleStatus status, Pageable pageable) {
+    public Page<Schedule> getByGeneration(Generation generation, String searchWord, ScheduleType scheduleType, ScheduleStatus status, Pageable pageable) {
         return scheduleRepository
-                .retrieveByGeneration(generation, searchWord, status, pageable);
+                .retrieveByGenerationAndScheduleType(generation, searchWord, scheduleType, status, pageable);
     }
 
     public Event addEvents(Schedule schedule, EventCreateDto dto) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -32,7 +32,7 @@ public class ScheduleService {
     public Schedule create(Generation generation, ScheduleCreateDto dto) {
         try {
             Location location = createLocation(dto);
-            Schedule schedule = Schedule.of(generation, dto.getName(), dto.getDateRange(), location);
+            Schedule schedule = Schedule.of(generation, dto.getName(), dto.getDateRange(), location, dto.getScheduleType());
 
             return scheduleRepository.save(schedule);
         } catch (DataIntegrityViolationException exception) {
@@ -129,6 +129,8 @@ public class ScheduleService {
 
         Location location = createLocation(scheduleCreateDto);
         schedule.changeLocation(location);
+
+        schedule.changeScheduleType(scheduleCreateDto.getScheduleType());
 
         return schedule;
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -1,9 +1,11 @@
 package kr.mashup.branding.facade.schedule;
 
 import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.member.Platform;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import kr.mashup.branding.service.generation.GenerationService;
+import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.schedule.ScheduleService;
 import kr.mashup.branding.ui.schedule.response.Progress;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponse;
@@ -25,6 +27,7 @@ public class ScheduleFacadeService {
 
     private final ScheduleService scheduleService;
     private final GenerationService generationService;
+    private final MemberService memberService;
 
     @Transactional(readOnly = true)
     public ScheduleResponse getById(Long id) {
@@ -36,29 +39,38 @@ public class ScheduleFacadeService {
 
     @Transactional(readOnly = true)
     public ScheduleResponseList getByGenerationNum(Integer generationNumber) {
-
         final Generation generation = generationService.getByNumberOrThrow(generationNumber);
+        List<Schedule> scheduleList = getFilteredSchedules(generation);
+        return createScheduleResponseList(generation, scheduleList);
+    }
 
-        final List<Schedule> scheduleList = scheduleService.getByGenerationAndStatus(generation, ScheduleStatus.PUBLIC);
+    @Transactional(readOnly = true)
+    public ScheduleResponseList getMemberSchedulesByGenerationNum(Integer generationNumber, Long memberId) {
+        final Platform platform = memberService.getLatestPlatform(memberService.findMemberById(memberId));
+        final Generation generation = generationService.getByNumberOrThrow(generationNumber);
+        List<Schedule> scheduleList = getFilteredSchedules(generation).stream()
+            .filter(schedule -> schedule.checkAvailabilityByPlatform(platform))
+            .toList();
+        return createScheduleResponseList(generation, scheduleList);
+    }
 
+    private List<Schedule> getFilteredSchedules(Generation generation) {
+        return scheduleService.getByGenerationAndStatus(generation, ScheduleStatus.PUBLIC);
+    }
+
+    private ScheduleResponseList createScheduleResponseList(Generation generation, List<Schedule> scheduleList) {
         final LocalDateTime currentTime = LocalDateTime.now();
-
         final List<ScheduleResponse> scheduleResponseList = new ArrayList<>();
         Optional<Integer> nextScheduleDayCountFromNow = Optional.empty();
 
-        for(final Schedule schedule : scheduleList){
-
+        for (final Schedule schedule : scheduleList) {
             final Integer dayCountFromNow = countDayFromNow(schedule.getStartedAt(), currentTime);
-
             nextScheduleDayCountFromNow = updateNextScheduleDayCountFromNow(nextScheduleDayCountFromNow, dayCountFromNow);
-
             final ScheduleResponse scheduleResponse = ScheduleResponse.from(schedule, dayCountFromNow);
             scheduleResponseList.add(scheduleResponse);
         }
 
-
         final Progress progress = calcuateScheduleProgress(generation, scheduleList, currentTime);
-
         return ScheduleResponseList.of(progress, nextScheduleDayCountFromNow, scheduleResponseList);
     }
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -39,13 +39,6 @@ public class ScheduleFacadeService {
     }
 
     @Transactional(readOnly = true)
-    public ScheduleResponseList getByGenerationNum(Integer generationNumber) {
-        final Generation generation = generationService.getByNumberOrThrow(generationNumber);
-        List<Schedule> scheduleList = getFilteredSchedules(generation);
-        return createScheduleResponseList(generation, scheduleList);
-    }
-
-    @Transactional(readOnly = true)
     public ScheduleResponseList getMemberSchedulesByGenerationNum(Integer generationNumber, Long memberId) {
         final Platform platform = memberService.getLatestPlatform(memberService.findMemberById(memberId));
         final Generation generation = generationService.getByNumberOrThrow(generationNumber);

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/schedule/ScheduleFacadeService.java
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -50,7 +51,7 @@ public class ScheduleFacadeService {
         final Generation generation = generationService.getByNumberOrThrow(generationNumber);
         List<Schedule> scheduleList = getFilteredSchedules(generation).stream()
             .filter(schedule -> schedule.checkAvailabilityByPlatform(platform))
-            .toList();
+            .collect(Collectors.toList());
         return createScheduleResponseList(generation, scheduleList);
     }
 

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
@@ -1,5 +1,6 @@
 package kr.mashup.branding.ui.schedule;
 
+import kr.mashup.branding.security.MemberAuth;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponse;
 import kr.mashup.branding.ui.schedule.response.ScheduleResponseList;
 import lombok.RequiredArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/schedules")
@@ -50,6 +52,26 @@ public class ScheduleController {
     ) {
         final ScheduleResponseList res =
             scheduleFacadeService.getByGenerationNum(generationNumber);
+
+        return ApiResponse.success(res);
+    }
+
+    @ApiOperation(
+        value = "기수로 내 스케줄 조회",
+        notes =
+            "<h2> Error Code</h2>" +
+                "<p>" +
+                "GENERATION_NOT_FOUND</br>" +
+                "SCHEDULE_NOT_FOUND" +
+                "</p>"
+    )
+    @GetMapping("/my/generations/{generationNumber}")
+    public ApiResponse<ScheduleResponseList> getMySchedulesByGenerationNumber(
+        @ApiIgnore MemberAuth auth,
+        @PathVariable Integer generationNumber
+    ) {
+        final ScheduleResponseList res =
+            scheduleFacadeService.getMemberSchedulesByGenerationNum(generationNumber, auth.getMemberId());
 
         return ApiResponse.success(res);
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/ScheduleController.java
@@ -48,25 +48,6 @@ public class ScheduleController {
     )
     @GetMapping("/generations/{generationNumber}")
     public ApiResponse<ScheduleResponseList> getByGenerationNumber(
-        @PathVariable Integer generationNumber
-    ) {
-        final ScheduleResponseList res =
-            scheduleFacadeService.getByGenerationNum(generationNumber);
-
-        return ApiResponse.success(res);
-    }
-
-    @ApiOperation(
-        value = "기수로 내 스케줄 조회",
-        notes =
-            "<h2> Error Code</h2>" +
-                "<p>" +
-                "GENERATION_NOT_FOUND</br>" +
-                "SCHEDULE_NOT_FOUND" +
-                "</p>"
-    )
-    @GetMapping("/my/generations/{generationNumber}")
-    public ApiResponse<ScheduleResponseList> getMySchedulesByGenerationNumber(
         @ApiIgnore MemberAuth auth,
         @PathVariable Integer generationNumber
     ) {

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/schedule/response/ScheduleResponse.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import kr.mashup.branding.domain.schedule.Location;
 import kr.mashup.branding.domain.schedule.Schedule;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import lombok.Getter;
 import lombok.Value;
 
@@ -27,6 +28,8 @@ public class ScheduleResponse {
 
     Location location;
 
+    ScheduleType scheduleType;
+
     List<EventResponse> eventList;
 
     public static ScheduleResponse from(Schedule schedule, Integer dateCount) {
@@ -38,6 +41,7 @@ public class ScheduleResponse {
             schedule.getEndedAt(),
             schedule.getGeneration().getNumber(),
             schedule.getLocation() == null ? null : schedule.getLocation(),
+            schedule.getScheduleType(),
             schedule.getEventList()
                 .stream()
                 .map(EventResponse::from)


### PR DESCRIPTION
## PR 타입

## 개요

##  변경사항

도메인
- 스케쥴 타입 추가
    - 생성/업데이트 할때 null이면 ALL로 추가되도록 방어로직 추가

배치
- 출석체크할때 스케쥴 기준으로 하는데, 이때 ALL만 가져오도록 조건 추가

멤버
- 스케줄 조회시 ALL이나 자신 플랫폼에 해당하는 스케쥴만 조회
    - 방어적으로 /my 로 하나 더 만들었습니당
    - 굳이 my로 분리할 필요없을거 같기도한데 이건 의견 부탁~~
- 세미나 업데이트 푸시노티 보낼때 팀별 설정

어드민
- request, response dto에 타입추가
- 조회시에 scheduleType 기본값 ALL(전체세미나)로 적용

##  배포 주의 사항
- 출첵배치나 출석관련해서 영향 없는 시간대에 배포
- 배포 전에 scheduleType 추가
- 전부다 기본값은 ALL로 추가
- admin, batch, member 배포