### PR TITLE
feat: 생일 축하 작업 추가

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/birthday/BirthdayCard.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/birthday/BirthdayCard.java
@@ -1,0 +1,58 @@
+package kr.mashup.branding.domain.birthday;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.domain.member.Platform;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class BirthdayCard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long senderMemberId;
+
+    private String senderMemberName;
+
+    @Enumerated(EnumType.STRING)
+    private Platform senderMemberPlatform;
+
+    private Long recipientMemberId;
+
+    private Long generationId;
+
+    private String message;
+
+    private String imageUrl;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public BirthdayCard(
+        Long recipientMemberId,
+        Member senderMember,
+        MemberGeneration senderMemberGeneration,
+        String message,
+        String imageUrl
+    ) {
+        this.senderMemberId = senderMember.getId();
+        this.senderMemberName = senderMember.getName();
+        this.senderMemberPlatform = senderMemberGeneration.getPlatform();
+        this.recipientMemberId = recipientMemberId;
+        this.generationId = senderMemberGeneration.getGeneration().getId();
+        this.message = message;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/birthday/CardImage.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/birthday/CardImage.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.domain.birthday;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CardImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/LinkType.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/LinkType.java
@@ -6,5 +6,6 @@ public enum LinkType {
     DANGGN,             // 당근 페이지
     MYPAGE,             // 마이 페이지
     DANGGN_REWARD,      // 당근 1등 리워드 페이지
+    BIRTHDAY,           // 생일 페이지
     ;
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/BirthdayRecipientVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/BirthdayRecipientVo.java
@@ -1,0 +1,18 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+import java.util.List;
+import java.util.Map;
+
+public class BirthdayRecipientVo extends PushNotiSendVo {
+    private static final String title = "오늘 생일이시군요";
+    private static final String body = "매숑이들이 준 선물을 확인해보세요❤️";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.BIRTHDAY.toString());
+
+    public BirthdayRecipientVo(List<Member> members) {
+        super(members, title, body, dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/BirthdaySenderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/BirthdaySenderVo.java
@@ -1,0 +1,18 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+import java.util.List;
+import java.util.Map;
+
+public class BirthdaySenderVo extends PushNotiSendVo {
+    private static final String title = "생일인 매숑들을 축하해 주세요.";
+    private static final String body = "오늘 생일인 매숑이들에게 축하 메세지를 남겨 보세요.";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.BIRTHDAY.toString());
+
+    public BirthdaySenderVo(List<Member> members) {
+        super(members, title, body, dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/birthday/BirthdayCardRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/birthday/BirthdayCardRepository.java
@@ -1,0 +1,15 @@
+package kr.mashup.branding.repository.birthday;
+
+import kr.mashup.branding.domain.birthday.BirthdayCard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BirthdayCardRepository extends JpaRepository<BirthdayCard, Long> {
+
+    List<BirthdayCard> findAllBySenderMemberIdAndGenerationId(Long senderMemberId, Long generationId);
+
+    Boolean existsBySenderMemberIdAndRecipientMemberIdAndGenerationId(Long senderMemberId, Long recipientMemberId, Long generationId);
+
+    List<BirthdayCard> findAllByRecipientMemberIdAndGenerationId(Long recipientMemberId, Long generationId);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/birthday/CardImageRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/birthday/CardImageRepository.java
@@ -1,0 +1,7 @@
+package kr.mashup.branding.repository.birthday;
+
+import kr.mashup.branding.domain.birthday.CardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardImageRepository extends JpaRepository<CardImage, Long> {
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
@@ -36,4 +36,3 @@ public class MemberGenerationRepositoryCustomImpl implements MemberGenerationRep
             .fetch();
     }
 }
-

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long> {
+public interface MemberProfileRepository extends JpaRepository<MemberProfile, Long>, MemberProfileRepositoryCustom {
 
     Optional<MemberProfile> findByMemberId(Long memberId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepositoryCustom.java
@@ -1,0 +1,12 @@
+package kr.mashup.branding.repository.member;
+
+import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.service.member.MemberBirthdayDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MemberProfileRepositoryCustom {
+
+    List<MemberBirthdayDto> retrieveByBirthDateBetween(LocalDate startDate, LocalDate endDate, Generation generation);
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberProfileRepositoryCustomImpl.java
@@ -1,0 +1,36 @@
+package kr.mashup.branding.repository.member;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.service.member.MemberBirthdayDto;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static kr.mashup.branding.domain.member.QMember.member;
+import static kr.mashup.branding.domain.member.QMemberGeneration.memberGeneration;
+import static kr.mashup.branding.domain.member.QMemberProfile.memberProfile;
+
+@RequiredArgsConstructor
+public class MemberProfileRepositoryCustomImpl implements MemberProfileRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MemberBirthdayDto> retrieveByBirthDateBetween(LocalDate startDate, LocalDate endDate, Generation generation) {
+        return queryFactory
+            .select(Projections.fields(
+                MemberBirthdayDto.class,
+                member.id.as("memberId"),
+                member.name.as("name"),
+                memberGeneration.platform.as("platform"),
+                memberProfile.birthDate.as("birthDate")
+            ))
+            .from(memberProfile)
+            .join(member).on(member.id.eq(memberProfile.memberId))
+            .join(memberGeneration).on(member.id.eq(memberGeneration.member.id))
+            .where(memberProfile.birthDate.between(startDate, endDate).and(memberGeneration.generation.eq(generation)))
+            .fetch();
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustom.java
@@ -22,4 +22,6 @@ public interface MemberRepositoryCustom {
     List<Member> findAllByCurrentGenerationAt(LocalDate at);
 
     List<Member> findAllActiveByGeneration(Generation generation);
+
+    List<Member> retrieveByBirthDate(Generation generation, LocalDate birthDate);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static kr.mashup.branding.domain.member.QMember.member;
 import static kr.mashup.branding.domain.member.QMemberGeneration.memberGeneration;
+import static kr.mashup.branding.domain.member.QMemberProfile.memberProfile;
 import static kr.mashup.branding.domain.scorehistory.QScoreHistory.scoreHistory;
 
 @RequiredArgsConstructor
@@ -145,5 +146,14 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .where(member.status.eq(MemberStatus.ACTIVE))
                 .fetch();
     }
-}
 
+    @Override
+    public List<Member> retrieveByBirthDate(Generation generation, LocalDate birthDate) {
+        return queryFactory
+            .selectFrom(member)
+            .innerJoin(memberProfile).on(memberProfile.memberId.eq(member.id))
+            .innerJoin(memberGeneration).on(memberGeneration.generation.eq(generation))
+            .where(memberProfile.birthDate.eq(birthDate))
+            .fetch();
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/birthday/BirthdayCardService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/birthday/BirthdayCardService.java
@@ -1,0 +1,48 @@
+package kr.mashup.branding.service.birthday;
+
+import kr.mashup.branding.domain.birthday.BirthdayCard;
+import kr.mashup.branding.domain.birthday.CardImage;
+import kr.mashup.branding.domain.exception.BadRequestException;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.repository.birthday.BirthdayCardRepository;
+import kr.mashup.branding.repository.birthday.CardImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BirthdayCardService {
+
+    private final CardImageRepository cardImageRepository;
+    private final BirthdayCardRepository birthdayCardRepository;
+
+    public List<CardImage> getDefault() {
+        return cardImageRepository.findAll();
+    }
+
+    public void checkAlreadySent(Long recipientMemberId, Member senderMember, MemberGeneration memberGeneration) {
+        if (birthdayCardRepository.existsBySenderMemberIdAndRecipientMemberIdAndGenerationId(senderMember.getId(), recipientMemberId, memberGeneration.getGeneration().getId())) {
+            throw new BadRequestException();
+        }
+    }
+
+    public void send(Long recipientMemberId, Member senderMember, MemberGeneration memberGeneration, String message, String imageUrl) {
+        birthdayCardRepository.save(
+            new BirthdayCard(
+                recipientMemberId,
+                senderMember,
+                memberGeneration,
+                message,
+                imageUrl
+            )
+        );
+    }
+
+    public List<BirthdayCard> getMy(Member recipientMember, MemberGeneration memberGeneration) {
+
+        return birthdayCardRepository.findAllByRecipientMemberIdAndGenerationId(recipientMember.getId(), memberGeneration.getGeneration().getId());
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/birthday/BirthdayService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/birthday/BirthdayService.java
@@ -1,0 +1,23 @@
+package kr.mashup.branding.service.birthday;
+
+import kr.mashup.branding.domain.birthday.BirthdayCard;
+import kr.mashup.branding.repository.birthday.BirthdayCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BirthdayService {
+
+    private final BirthdayCardRepository birthdayCardRepository;
+
+    public Set<Long> getSentBirthdayCardMemberIds(Long senderMemberId, Long generationId) {
+        return birthdayCardRepository.findAllBySenderMemberIdAndGenerationId(senderMemberId, generationId)
+            .stream()
+            .map(BirthdayCard::getRecipientMemberId)
+            .collect(Collectors.toSet());
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
@@ -4,7 +4,11 @@ import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.NotFoundException;
 import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.generation.GenerationStatus;
 import kr.mashup.branding.domain.generation.exception.GenerationNotFoundException;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.domain.member.exception.InactiveGenerationException;
 import kr.mashup.branding.repository.generation.GenerationRepository;
 import kr.mashup.branding.service.generation.vo.GenerationCreateVo;
 import kr.mashup.branding.service.generation.vo.GenerationUpdateVo;
@@ -17,6 +21,7 @@ import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -86,5 +91,14 @@ public class GenerationService {
                 .stream()
                 .filter(generation -> DateUtil.isInTime(generation.getStartedAt(), generation.getEndedAt(), at))
                 .collect(Collectors.toList());
+    }
+
+    public Generation getCurrentGeneration(Member member) {
+        return member.getMemberGenerations()
+            .stream()
+            .map(MemberGeneration::getGeneration)
+            .max(Comparator.comparingInt(Generation::getNumber))
+            .filter(gen -> GenerationStatus.ON_GOING.equals(gen.getStatus()))
+            .orElseThrow(InactiveGenerationException::new);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/generation/GenerationService.java
@@ -4,7 +4,6 @@ import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.NotFoundException;
 import kr.mashup.branding.domain.generation.Generation;
-import kr.mashup.branding.domain.generation.GenerationStatus;
 import kr.mashup.branding.domain.generation.exception.GenerationNotFoundException;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
@@ -98,7 +97,7 @@ public class GenerationService {
             .stream()
             .map(MemberGeneration::getGeneration)
             .max(Comparator.comparingInt(Generation::getNumber))
-            .filter(gen -> GenerationStatus.ON_GOING.equals(gen.getStatus()))
+            .filter(generation -> generation.isInProgress(LocalDate.now()))
             .orElseThrow(InactiveGenerationException::new);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberBirthdayDto.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberBirthdayDto.java
@@ -1,0 +1,15 @@
+package kr.mashup.branding.service.member;
+
+import kr.mashup.branding.domain.member.Platform;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberBirthdayDto {
+
+    private Long memberId;
+    private String name;
+    private Platform platform;
+    private LocalDate birthDate;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberProfileService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberProfileService.java
@@ -1,5 +1,6 @@
 package kr.mashup.branding.service.member;
 
+import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.member.MemberProfile;
 import kr.mashup.branding.repository.member.MemberProfileRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Slf4j
@@ -47,5 +49,9 @@ public class MemberProfileService {
     public MemberProfile findOrSave(Long memberId) {
         return memberProfileRepository.findByMemberId(memberId)
                 .orElseGet(() -> memberProfileRepository.save(MemberProfile.from(memberId)));
+    }
+
+    public List<MemberBirthdayDto> findByBirthDateBetween(LocalDate startDate, LocalDate endDate, Generation generation) {
+        return memberProfileRepository.retrieveByBirthDateBetween(startDate, endDate, generation);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -1,31 +1,20 @@
 package kr.mashup.branding.service.member;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import kr.mashup.branding.domain.schedule.Schedule;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.mashup.branding.domain.BaseEntity;
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
 import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.generation.GenerationStatus;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.MemberStatus;
 import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.domain.member.exception.InactiveGenerationException;
 import kr.mashup.branding.domain.member.exception.MemberLoginFailException;
 import kr.mashup.branding.domain.member.exception.MemberNotFoundException;
 import kr.mashup.branding.domain.member.exception.MemberPendingException;
+import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.repository.attendance.AttendanceRepository;
 import kr.mashup.branding.repository.danggn.DanggnNotificationMemberRecordRepository;
 import kr.mashup.branding.repository.danggn.DanggnScoreRepository;
@@ -38,6 +27,18 @@ import kr.mashup.branding.repository.scorehistory.ScoreHistoryRepository;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -160,11 +161,11 @@ public class MemberService {
     public void resetPassword(
         final String identification,
         final String newPassword
-    ){
+    ) {
         final Member member = memberRepository.findByIdentification(identification)
-                .orElseThrow(MemberNotFoundException::new);
+            .orElseThrow(MemberNotFoundException::new);
 
-        member.setPassword(newPassword,passwordEncoder);
+        member.setPassword(newPassword, passwordEncoder);
     }
 
     public void deleteMember(Long memberId) {
@@ -188,6 +189,7 @@ public class MemberService {
     public boolean existsIdentification(String identification) {
         return memberRepository.existsByIdentification(identification);
     }
+
     private void checkActiveStatus(Member member) {
         if (member.getStatus() != MemberStatus.ACTIVE) {
             throw new MemberPendingException();
@@ -225,7 +227,7 @@ public class MemberService {
 
     public MemberGeneration findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber) {
         return memberGenerationRepository.findByMemberIdAndGenerationNumber(memberId, generationNumber)
-                .orElseThrow(GenerationIntegrityFailException::new);
+            .orElseThrow(GenerationIntegrityFailException::new);
     }
 
     public Boolean existMemberGenerationByMemberAndGeneration(Member member, Generation generation) {
@@ -234,8 +236,8 @@ public class MemberService {
 
     public List<Member> getAllDanggnPushNotiTargetableMembers() {
         return memberRepository.findAllByCurrentGenerationAt(LocalDate.now()).stream()
-                .filter(Member::getDanggnPushNotificationAgreed)
-                .collect(Collectors.toList());
+            .filter(Member::getDanggnPushNotificationAgreed)
+            .collect(Collectors.toList());
     }
 
     public MemberGeneration findByMemberGenerationId(Long memberGenerationId) {
@@ -267,7 +269,7 @@ public class MemberService {
                     if (existMemberGenerationByMemberAndGeneration(member, generation)) { // memberGeneration 있을면 삭제
 
                         final MemberGeneration memberGeneration
-                                = findByMemberIdAndGenerationNumber(member.getId(), generation.getNumber());
+                            = findByMemberIdAndGenerationNumber(member.getId(), generation.getNumber());
 
                         deleteMemberGeneration(memberGeneration);
                     }
@@ -290,21 +292,21 @@ public class MemberService {
     }
 
     public void updateMemberGeneration(
-            Long memberGenerationId,
-            String projectTeamName,
-            String role
+        Long memberGenerationId,
+        String projectTeamName,
+        String role
     ) {
         var memberGeneration = memberGenerationRepository.findById(memberGenerationId)
-                .orElseThrow(GenerationIntegrityFailException::new);
+            .orElseThrow(GenerationIntegrityFailException::new);
         memberGeneration.updateProjectInfo(
-                projectTeamName,
-                role
+            projectTeamName,
+            role
         );
     }
 
     public List<Member> findAllByMemberIds(final List<Long> memberIds) {
         final List<Member> members = memberRepository.findAllById(memberIds);
-        if(memberIds.size() != members.size()){
+        if (memberIds.size() != members.size()) {
             throw new MemberNotFoundException();
         }
 
@@ -329,7 +331,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void dropOut(final Generation generation,final List<Member> members) {
+    public void dropOut(final Generation generation, final List<Member> members) {
 
         final List<Long> memberIds = members.stream().map(BaseEntity::getId).collect(Collectors.toList());
 
@@ -338,8 +340,32 @@ public class MemberService {
             .forEach(MemberGeneration::dropOut);
     }
 
+    public MemberGeneration getCurrentMemberGeneration(Member member) {
+        return member.getMemberGenerations()
+            .stream()
+            .filter(mg -> GenerationStatus.ON_GOING.equals(mg.getGeneration().getStatus()))
+            .max(Comparator.comparingInt(mg -> mg.getGeneration().getNumber()))
+            .orElseThrow(InactiveGenerationException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Member> getAllByBirthdayRecipient(Generation generation) {
+        return memberRepository.retrieveByBirthDate(generation, LocalDate.now());
+    }
+
+    @Transactional(readOnly = true)
+    public List<Member> getAllByBirthdaySender(Generation generation) {
+
+        List<Member> senders = memberRepository.findAllActiveByGeneration(generation);
+        List<Member> recipients = memberRepository.retrieveByBirthDate(generation, LocalDate.now());
+        senders.removeAll(recipients);
+
+        return senders;
+    }
+
+
     @Transactional
-    public void updatePushCheckTime(final Member member){
+    public void updatePushCheckTime(final Member member) {
         member.updatePushCheckTime(LocalDateTime.now());
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -5,7 +5,6 @@ import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
 import kr.mashup.branding.domain.generation.Generation;
-import kr.mashup.branding.domain.generation.GenerationStatus;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.MemberStatus;
@@ -343,7 +342,7 @@ public class MemberService {
     public MemberGeneration getCurrentMemberGeneration(Member member) {
         return member.getMemberGenerations()
             .stream()
-            .filter(mg -> GenerationStatus.ON_GOING.equals(mg.getGeneration().getStatus()))
+            .filter(memberGeneration -> memberGeneration.getGeneration().isInProgress(LocalDate.now()))
             .max(Comparator.comparingInt(mg -> mg.getGeneration().getNumber()))
             .orElseThrow(InactiveGenerationException::new);
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayCardFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayCardFacadeService.java
@@ -1,0 +1,63 @@
+package kr.mashup.branding.facade.birthday;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.service.birthday.BirthdayCardService;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.ui.birthday.request.BirthdayCardRequest;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardDefaultImageResponse;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardDefaultImagesResponse;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardResponse;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BirthdayCardFacadeService {
+
+    private final BirthdayCardService birthdayCardService;
+    private final MemberService memberService;
+
+    @Transactional(readOnly = true)
+    public BirthdayCardDefaultImagesResponse getDefault() {
+        List<BirthdayCardDefaultImageResponse> cardImages = birthdayCardService.getDefault()
+            .stream()
+            .map(cardImage -> BirthdayCardDefaultImageResponse.of(cardImage.getImageUrl()))
+            .collect(Collectors.toList());
+
+        return BirthdayCardDefaultImagesResponse.of(cardImages);
+    }
+
+    @Transactional
+    public void send(Long memberId, BirthdayCardRequest request) {
+        Member senderMember = memberService.findMemberById(memberId);
+        MemberGeneration latestMemberGeneration = memberService.getCurrentMemberGeneration(senderMember);
+
+        birthdayCardService.checkAlreadySent(request.getRecipientMemberId(), senderMember, latestMemberGeneration);
+        birthdayCardService.send(request.getRecipientMemberId(), senderMember, latestMemberGeneration, request.getMessage(), request.getImageUrl());
+    }
+
+    @Transactional(readOnly = true)
+    public BirthdayCardsResponse getMy(Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+        MemberGeneration generation = memberService.getCurrentMemberGeneration(member);
+
+        List<BirthdayCardResponse> birthdayCards = birthdayCardService.getMy(member, generation)
+            .stream()
+            .map(birthdayCard -> BirthdayCardResponse.of(
+                birthdayCard.getId(),
+                birthdayCard.getSenderMemberName(),
+                birthdayCard.getSenderMemberPlatform().getName(),
+                birthdayCard.getMessage(),
+                birthdayCard.getMessage()
+            ))
+            .collect(Collectors.toList());
+
+        return BirthdayCardsResponse.of(birthdayCards);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayFacadeService.java
@@ -1,0 +1,85 @@
+package kr.mashup.branding.facade.birthday;
+
+import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.vo.BirthdayRecipientVo;
+import kr.mashup.branding.domain.pushnoti.vo.BirthdaySenderVo;
+import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
+import kr.mashup.branding.service.birthday.BirthdayService;
+import kr.mashup.branding.service.generation.GenerationService;
+import kr.mashup.branding.service.member.MemberBirthdayDto;
+import kr.mashup.branding.service.member.MemberProfileService;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.ui.member.response.MemberBirthdaysResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BirthdayFacadeService {
+    private final MemberProfileService memberProfileService;
+    private final MemberService memberService;
+    private final GenerationService generationService;
+    private final BirthdayService birthdayService;
+
+    private final PushNotiEventPublisher pushNotiEventPublisher;
+
+    /**
+     * 다가오는 생일 멤버 정보를 조회 <p>
+     * 이미 생일 카드를 보낸 멤버들의 ID를 조회
+     *
+     * @param memberId 조회하는 멤버 ID
+     * @param days     다가오는 생일을 확인할 기간 (일 수)
+     * @return 다가오는 생일자 정보
+     */
+    @Transactional(readOnly = true)
+    public MemberBirthdaysResponse getUpcomingBirthdays(Long memberId, Integer days) {
+        Member member = memberService.findMemberById(memberId);
+        Generation generation = generationService.getCurrentGeneration(member);
+
+        Map<LocalDate, List<MemberBirthdayDto>> upcomingBirthdays = calculateUpcomingBirthdays(member, days, generation);
+        Set<Long> sentMemberIds = birthdayService.getSentBirthdayCardMemberIds(memberId, generation.getId());
+
+        return MemberBirthdaysResponse.of(sentMemberIds, upcomingBirthdays);
+    }
+
+    private Map<LocalDate, List<MemberBirthdayDto>> calculateUpcomingBirthdays(Member member, Integer days, Generation generation) {
+        LocalDate now = LocalDate.now();
+        return memberProfileService.findByBirthDateBetween(now, now.plusDays(days), generation)
+            .stream()
+            .filter(birthdayDto -> birthdayDto.getMemberId() != member.getId())
+            .collect(Collectors.groupingBy(MemberBirthdayDto::getBirthDate));
+    }
+
+    /**
+     * 생일자인 경우, 생일 리마인드 푸시
+     */
+    @Scheduled(cron = "0 0 24 * * ?")
+    @Transactional(readOnly = true)
+    public void sendBirthdayPushNotiForRecipient() {
+        generationService.getAllActiveInAt(LocalDate.now())
+            .forEach(generation -> pushNotiEventPublisher.publishPushNotiSendEvent(
+                new BirthdayRecipientVo(memberService.getAllByBirthdayRecipient(generation))
+            ));
+    }
+
+    /**
+     * 생일자가 아닌 경우, 생일 축하 독려 푸시
+     */
+    @Scheduled(cron = "0 0 12 * * ?")
+    @Transactional(readOnly = true)
+    public void sendBirthdayPushNotiForSender() {
+        generationService.getAllActiveInAt(LocalDate.now())
+            .forEach(generation -> pushNotiEventPublisher.publishPushNotiSendEvent(
+                new BirthdaySenderVo(memberService.getAllByBirthdaySender(generation))
+            ));
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberProfileFacadeService.java
@@ -1,14 +1,13 @@
 package kr.mashup.branding.facade.member;
 
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.service.member.MemberProfileService;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.member.request.MemberProfileRequest;
 import kr.mashup.branding.ui.member.response.MemberProfileResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,17 +19,17 @@ public class MemberProfileFacadeService {
     @Transactional
     public Boolean updateMyProfile(Long memberId, MemberProfileRequest request) {
         memberProfileService.updateOrSave(
-                memberId,
-                request.getBirthDate(),
-                request.getJob(),
-                request.getCompany(),
-                request.getIntroduction(),
-                request.getResidence(),
-                request.getSocialNetworkServiceLink(),
-                request.getGithubLink(),
-                request.getPortfolioLink(),
-                request.getBlogLink(),
-                request.getLinkedInLink()
+            memberId,
+            request.getBirthDate(),
+            request.getJob(),
+            request.getCompany(),
+            request.getIntroduction(),
+            request.getResidence(),
+            request.getSocialNetworkServiceLink(),
+            request.getGithubLink(),
+            request.getPortfolioLink(),
+            request.getBlogLink(),
+            request.getLinkedInLink()
         );
 
         return true;

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/BirthdayCardController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/BirthdayCardController.java
@@ -1,0 +1,52 @@
+package kr.mashup.branding.ui.birthday;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.birthday.BirthdayCardFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.birthday.request.BirthdayCardRequest;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardDefaultImagesResponse;
+import kr.mashup.branding.ui.birthday.response.BirthdayCardsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+
+@Slf4j
+@RestController
+@RequestMapping("api/v1/birthday-cards")
+@RequiredArgsConstructor
+public class BirthdayCardController {
+    private final BirthdayCardFacadeService birthdayCardFacadeService;
+
+    @ApiOperation("기본 축하 카드 조회")
+    @GetMapping("/default-images")
+    public ApiResponse<BirthdayCardDefaultImagesResponse> getDefault() {
+        final BirthdayCardDefaultImagesResponse response
+            = birthdayCardFacadeService.getDefault();
+
+        return ApiResponse.success(response);
+    }
+
+    @ApiOperation("생일 축하 카드 보내기")
+    @PostMapping
+    public ApiResponse<String> send(
+        @ApiIgnore MemberAuth memberAuth,
+        @Valid @RequestBody BirthdayCardRequest request
+    ) {
+        birthdayCardFacadeService.send(memberAuth.getMemberId(), request);
+
+        return ApiResponse.success("생일 카드가 잘 전달되었어요.");
+    }
+
+    @ApiOperation("나의 생일 축하 카드 조회")
+    @GetMapping
+    public ApiResponse<BirthdayCardsResponse> getMy(@ApiIgnore MemberAuth memberAuth) {
+        final BirthdayCardsResponse response
+            = birthdayCardFacadeService.getMy(memberAuth.getMemberId());
+
+        return ApiResponse.success(response);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/BirthdayController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/BirthdayController.java
@@ -1,0 +1,34 @@
+package kr.mashup.branding.ui.birthday;
+
+import io.swagger.annotations.ApiOperation;
+import kr.mashup.branding.facade.birthday.BirthdayFacadeService;
+import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.ui.ApiResponse;
+import kr.mashup.branding.ui.member.response.MemberBirthdaysResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Slf4j
+@RestController
+@RequestMapping("api/v1/birthdays")
+@RequiredArgsConstructor
+public class BirthdayController {
+    private final BirthdayFacadeService birthdayFacadeService;
+
+    @ApiOperation("다가오는 생일자 조회")
+    @GetMapping("/upcoming")
+    public ApiResponse<MemberBirthdaysResponse> getUpcomingBirthdays(
+        @ApiIgnore MemberAuth memberAuth,
+        @RequestParam(defaultValue = "7", required = false) Integer days
+    ) {
+        final MemberBirthdaysResponse response
+            = birthdayFacadeService.getUpcomingBirthdays(memberAuth.getMemberId(), days);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/request/BirthdayCardRequest.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/request/BirthdayCardRequest.java
@@ -1,0 +1,15 @@
+package kr.mashup.branding.ui.birthday.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@RequiredArgsConstructor
+public class BirthdayCardRequest {
+    private final long recipientMemberId;
+    @Size(max = 50, message = "생일 축하 메시지는 50글자를 초과할 수 없습니다.")
+    private final String message;
+    private final String imageUrl;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardDefaultImageResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardDefaultImageResponse.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.ui.birthday.response;
+
+import lombok.Getter;
+import lombok.Value;
+
+@Getter
+@Value(staticConstructor = "of")
+public class BirthdayCardDefaultImageResponse {
+    String imageUrl;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardDefaultImagesResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardDefaultImagesResponse.java
@@ -1,0 +1,12 @@
+package kr.mashup.branding.ui.birthday.response;
+
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.List;
+
+@Getter
+@Value(staticConstructor = "of")
+public class BirthdayCardDefaultImagesResponse {
+    List<BirthdayCardDefaultImageResponse> defaultImages;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardResponse.java
@@ -1,0 +1,14 @@
+package kr.mashup.branding.ui.birthday.response;
+
+import lombok.Getter;
+import lombok.Value;
+
+@Getter
+@Value(staticConstructor = "of")
+public class BirthdayCardResponse {
+    Long id;
+    String senderMemberName;
+    String senderMemberPlatform;
+    String message;
+    String imageUrl;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardsResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/birthday/response/BirthdayCardsResponse.java
@@ -1,0 +1,12 @@
+package kr.mashup.branding.ui.birthday.response;
+
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.List;
+
+@Getter
+@Value(staticConstructor = "of")
+public class BirthdayCardsResponse {
+    List<BirthdayCardResponse> birthdayCards;
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberProfileController.java
@@ -1,14 +1,5 @@
 package kr.mashup.branding.ui.member;
 
-import javax.validation.Valid;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import io.swagger.annotations.ApiOperation;
 import kr.mashup.branding.facade.member.MemberProfileFacadeService;
 import kr.mashup.branding.security.MemberAuth;
@@ -16,7 +7,10 @@ import kr.mashup.branding.ui.ApiResponse;
 import kr.mashup.branding.ui.member.request.MemberProfileRequest;
 import kr.mashup.branding.ui.member.response.MemberProfileResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("api/v1/member-profiles")
@@ -28,10 +22,10 @@ public class MemberProfileController {
     @ApiOperation("나의 프로필 조회")
     @GetMapping("/my")
     public ApiResponse<MemberProfileResponse> getMyProfile(
-            @ApiIgnore MemberAuth memberAuth
+        @ApiIgnore MemberAuth memberAuth
     ) {
         final MemberProfileResponse response
-                = memberProfileFacadeService.getMyProfile(memberAuth.getMemberId());
+            = memberProfileFacadeService.getMyProfile(memberAuth.getMemberId());
 
         return ApiResponse.success(response);
     }
@@ -39,11 +33,11 @@ public class MemberProfileController {
     @ApiOperation("나의 프로필 업데이트")
     @PatchMapping("/my")
     public ApiResponse<Boolean> updateMyProfile(
-            @ApiIgnore MemberAuth memberAuth,
-            @Valid @RequestBody MemberProfileRequest request
+        @ApiIgnore MemberAuth memberAuth,
+        @Valid @RequestBody MemberProfileRequest request
     ) {
         final Boolean response
-                = memberProfileFacadeService.updateMyProfile(memberAuth.getMemberId(), request);
+            = memberProfileFacadeService.updateMyProfile(memberAuth.getMemberId(), request);
 
         return ApiResponse.success(response);
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberBirthdayResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberBirthdayResponse.java
@@ -1,0 +1,23 @@
+package kr.mashup.branding.ui.member.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberBirthdayResponse {
+
+    private final LocalDate date;
+    private final List<Member> members;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Member {
+        private final String name;
+        private final String platform;
+        private final boolean congratulated;
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberBirthdaysResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberBirthdaysResponse.java
@@ -1,0 +1,60 @@
+package kr.mashup.branding.ui.member.response;
+
+import kr.mashup.branding.service.member.MemberBirthdayDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class MemberBirthdaysResponse {
+
+    private final MemberBirthdayResponse todayBirthday;
+
+    private final List<MemberBirthdayResponse> upcomingBirthdays;
+
+    public static MemberBirthdaysResponse of(Set<Long> sentMemberIds, Map<LocalDate, List<MemberBirthdayDto>> upcomingBirthdays) {
+        List<MemberBirthdayResponse> responses = createResponses(sentMemberIds, upcomingBirthdays);
+
+        LocalDate today = LocalDate.now();
+        MemberBirthdayResponse todayBirthday = extractTodayBirthday(today, responses);
+        List<MemberBirthdayResponse> sortedResponses = sortUpcomingBirthdays(today, responses);
+
+        return new MemberBirthdaysResponse(todayBirthday, sortedResponses);
+    }
+
+    private static List<MemberBirthdayResponse> createResponses(Set<Long> sentMemberIds, Map<LocalDate, List<MemberBirthdayDto>> birthdayDtos) {
+        return birthdayDtos.entrySet().stream()
+            .map(entry -> new MemberBirthdayResponse(
+                entry.getKey(),
+                entry.getValue().stream()
+                    .map(dto -> new MemberBirthdayResponse.Member(
+                        dto.getName(),
+                        dto.getPlatform().getName(),
+                        sentMemberIds.contains(dto.getMemberId())
+                    ))
+                    .collect(Collectors.toList())
+            ))
+            .collect(Collectors.toList());
+    }
+
+    private static MemberBirthdayResponse extractTodayBirthday(LocalDate today, List<MemberBirthdayResponse> responses) {
+        return responses.stream()
+            .filter(response -> today.equals(response.getDate()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private static List<MemberBirthdayResponse> sortUpcomingBirthdays(LocalDate today, List<MemberBirthdayResponse> responses) {
+        return responses.stream()
+            .filter(response -> !today.equals(response.getDate()))
+            .sorted(Comparator.comparing(MemberBirthdayResponse::getDate).reversed())
+            .collect(Collectors.toList());
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationResponse.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/response/MemberGenerationResponse.java
@@ -23,12 +23,12 @@ public class MemberGenerationResponse {
 
     public static MemberGenerationResponse of(MemberGeneration memberGeneration) {
         return new MemberGenerationResponse(
-                memberGeneration.getId(),
-                memberGeneration.getGeneration().getNumber(),
-                memberGeneration.getPlatform().getName(),
-                memberGeneration.getProjectTeamName(),
-                memberGeneration.getRole(),
-                memberGeneration.getGeneration().getStatus()
+            memberGeneration.getId(),
+            memberGeneration.getGeneration().getNumber(),
+            memberGeneration.getPlatform().getName(),
+            memberGeneration.getProjectTeamName(),
+            memberGeneration.getRole(),
+            memberGeneration.getGeneration().getStatus()
         );
     }
 }


### PR DESCRIPTION
## PR 타입

## 개요

- 생일자 조회 API(GET /birthdays/upcoming)
- 기본 축하 카드 조회 API(GET /birthday-cards/default-images)
- 생일 축하 카드 생성 API(POST /birthday-cards)
- 나의 생일 축하 카드 조회 API(GET /birthday-cards)
- 생일 축하 조회 푸시 알림 스케줄러
- 생일 축하 독촉 푸시 알림 스케줄러

##  변경사항

