### PR TITLE
MashongMission에서 다음 미션 레벨 얻어올 때 없으면 null이 아니라 max 값을 반환하게 수정

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/mashong/MashongMission.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/mashong/MashongMission.java
@@ -36,8 +36,11 @@ public class MashongMission {
 
     public MashongMissionLevel getNextMissionLevel(Long level) {
         return mashongMissionLevelList.stream()
-            .filter(missionLevel -> missionLevel.getLevel() == level + 1)
-            .findFirst()
-            .orElseGet(null);
+                .filter(missionLevel -> missionLevel.getLevel() == level + 1)
+                .findFirst()
+                .orElseGet(() -> mashongMissionLevelList.stream()
+                        .max(Comparator.comparing(MashongMissionLevel::getLevel))
+                        .orElseThrow(IllegalStateException::new)
+                );
     }
 }


### PR DESCRIPTION
## PR 타입

## 개요

##  변경사항

