### PR TITLE
ci: tag 추가

### DIFF
--- a/.github/workflows/cd-dev-recruit.yml
+++ b/.github/workflows/cd-dev-recruit.yml
@@ -36,4 +36,4 @@ jobs:
           script: |
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 321148231533.dkr.ecr.ap-northeast-2.amazonaws.com
             cd /home/ec2-user/mashup-server/docker/deploy/recruit/dev
-            sh ./deploy-recruit.sh
+            sh ./deploy-recruit.sh $TAG

--- a/.github/workflows/ci-dev-tag.yml
+++ b/.github/workflows/ci-dev-tag.yml
@@ -1,0 +1,38 @@
+name: Mash-Up Tag Dev CI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: 'gradle'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build Jib
+        run: |
+          chmod +x gradlew
+          ./gradlew :mashup-member:jib -PbuildPhase=develop -PencryptorPassword=${{ secrets.ENCRYPTOR_PASSWORD }} -Ptag=$GITHUB_REF_NAME
+          ./gradlew :mashup-admin:jib -PbuildPhase=develop -PencryptorPassword=${{ secrets.ENCRYPTOR_PASSWORD }} -Ptag=$GITHUB_REF_NAME
+          ./gradlew :mashup-recruit:jib -PbuildPhase=develop -PencryptorPassword=${{ secrets.ENCRYPTOR_PASSWORD }} -Ptag=$GITHUB_REF_NAME

--- a/mashup-admin/jib.gradle
+++ b/mashup-admin/jib.gradle
@@ -6,7 +6,7 @@ jib {
     }
     to {
         image = "321148231533.dkr.ecr.ap-northeast-2.amazonaws.com/${project.name}"
-        tags = ["${buildPhase}"]
+        tags = ["${project.findProperty('tag') ?: buildPhase}"]
         println "to image : ${image}:${tags}"
     }
     container {

--- a/mashup-member/jib.gradle
+++ b/mashup-member/jib.gradle
@@ -6,7 +6,7 @@ jib {
     }
     to {
         image = "321148231533.dkr.ecr.ap-northeast-2.amazonaws.com/${project.name}"
-        tags = ["${buildPhase}"]
+        tags = ["${project.findProperty('tag') ?: buildPhase}"]
         println "to image : ${image}:${tags}"
     }
     container {

--- a/mashup-recruit/jib.gradle
+++ b/mashup-recruit/jib.gradle
@@ -6,7 +6,7 @@ jib {
     }
     to {
         image = "321148231533.dkr.ecr.ap-northeast-2.amazonaws.com/${project.name}"
-        tags = ["${buildPhase}"]
+        tags = ["${project.findProperty('tag') ?: buildPhase}"]
         println "to image : ${image}:${tags}"
     }
     container {


### PR DESCRIPTION
## PR 타입

## 개요
- 태그 기반으로 CI 동작하도록 깃헙 액션 추가
- develop 외에도 생성한 태그로 배포 가능하도록 변경(dev 에서 정상 동작 확인)
<img width="328" alt="image" src="https://github.com/mash-up-kr/mashup-server/assets/66551410/5e9c68af-d0b7-4da3-9064-140b00f25186">

##  변경사항

