### PR TITLE
Mashong Mission Event로 분리

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/dto/MissionEventType.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/dto/MissionEventType.java
@@ -1,0 +1,12 @@
+package kr.mashup.branding.service.mashong.dto;
+
+public enum MissionEventType {
+
+    APPLY,
+    SET_TO_VALUE,
+    ;
+
+    public boolean isApplyType() {
+        return this.equals(APPLY);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/event/MashongMissionEvent.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/event/MashongMissionEvent.java
@@ -1,0 +1,22 @@
+package kr.mashup.branding.service.mashong.event;
+
+
+import kr.mashup.branding.domain.mashong.MissionStrategyType;
+import kr.mashup.branding.domain.member.MemberGeneration;
+import kr.mashup.branding.service.mashong.dto.MissionEventType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MashongMissionEvent {
+
+    private final MissionStrategyType missionStrategyType;
+    private final MemberGeneration memberGeneration;
+    private final Double value;
+    private final MissionEventType eventType;
+
+    public boolean isApplyEvent() {
+        return eventType.isApplyType();
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/event/MashongMissionEventPublisher.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/mashong/event/MashongMissionEventPublisher.java
@@ -1,0 +1,18 @@
+package kr.mashup.branding.service.mashong.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MashongMissionEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publish(MashongMissionEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/config/async/AsyncConfig.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/config/async/AsyncConfig.java
@@ -20,4 +20,13 @@ public class AsyncConfig {
         return taskExecutor;
     }
 
+    @Bean(name = ThreadPoolName.MASHONG_MISSION_THREAD_POOL)
+    public Executor mashongMissionThreadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(3);
+        taskExecutor.setMaxPoolSize(30);
+        taskExecutor.setQueueCapacity(100);
+        taskExecutor.setThreadNamePrefix("Executor-");
+        return taskExecutor;
+    }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/config/async/ThreadPoolName.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/config/async/ThreadPoolName.java
@@ -2,4 +2,5 @@ package kr.mashup.branding.config.async;
 
 public class ThreadPoolName {
     public static final String PUSH_NOTI_SEND_THREAD_POOL = "PUSH_NOTI_SEND_THREAD_POOL";
+    public static final String MASHONG_MISSION_THREAD_POOL = "MASHONG_MISSION_THREAD_POOL";
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/mashong/MashongMissionFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/mashong/MashongMissionFacadeService.java
@@ -11,6 +11,7 @@ import kr.mashup.branding.service.mashong.dto.MissionStatus;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.ui.mashong.response.MashongAttendanceResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MashongMissionFacadeService {

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/mashong/MashongMissionEventListener.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/mashong/MashongMissionEventListener.java
@@ -1,0 +1,45 @@
+package kr.mashup.branding.ui.mashong;
+
+import kr.mashup.branding.config.async.ThreadPoolName;
+import kr.mashup.branding.facade.mashong.MashongMissionFacadeService;
+import kr.mashup.branding.service.mashong.event.MashongMissionEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MashongMissionEventListener {
+
+    private final MashongMissionFacadeService mashongMissionFacadeService;
+
+    @Async(value = ThreadPoolName.MASHONG_MISSION_THREAD_POOL)
+    @Transactional(propagation = Propagation.NEVER)
+    @TransactionalEventListener
+    public void handleMashongMissionEvent(MashongMissionEvent event) {
+        log.info("MASHONG_MISSION_{}_EVENT_LISTEN :: memberGenerationId = {}",
+                event.getEventType(),
+                event.getMemberGeneration().getId()
+        );
+
+        if (event.isApplyEvent()) {
+            mashongMissionFacadeService.apply(
+                    event.getMissionStrategyType(),
+                    event.getMemberGeneration(),
+                    event.getValue()
+            );
+            return;
+        }
+
+        mashongMissionFacadeService.setToValue(
+                event.getMissionStrategyType(),
+                event.getMemberGeneration(),
+                event.getValue()
+        );
+    }
+}


### PR DESCRIPTION
## PR 타입

## 개요

##  변경사항
- DaggnFacade, MashongFacade에 있던 MashongMissionFacade 의존성 MashongMissionEventPublisher로 대체
