### PR TITLE
feat: fcm deprecated api 대응

### DIFF
--- a/mashup-admin/src/main/java/kr/mashup/branding/ui/pushnoti/PushNotiEventListener.java
+++ b/mashup-admin/src/main/java/kr/mashup/branding/ui/pushnoti/PushNotiEventListener.java
@@ -39,7 +39,7 @@ public class PushNotiEventListener {
             pushNotiService.sendPushNotification(event);
         }catch (Exception ignored){
             log.error("[SEND_PUSH_FAIL] failed to send push memberIds {} , title {} , body {}",
-                    extractMemberIds(event), event.getTitle(), event.getBody());
+                extractMemberIds(event), event.getTitle(), event.getBody(), ignored);
         }
     }
 

--- a/mashup-domain/build.gradle
+++ b/mashup-domain/build.gradle
@@ -22,7 +22,7 @@ dependencies{
     implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:$jasyptVersion"
     implementation 'com.querydsl:querydsl-jpa'
     implementation 'com.querydsl:querydsl-apt'
-    implementation 'com.google.firebase:firebase-admin:7.1.0'
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/FcmPushNotiService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/FcmPushNotiService.java
@@ -1,22 +1,20 @@
 package kr.mashup.branding.infrastructure.pushnoti;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
-
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.pushnoti.exception.PushNotiException;
 import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -34,7 +32,7 @@ public class FcmPushNotiService implements PushNotiService {
             .addAllTokens(getAgreedFcmTokens(pushNotiSendVo.getMembers()))
             .build();
         try {
-            FirebaseMessaging.getInstance(firebaseApp).sendMulticast(multicastMessage);
+            FirebaseMessaging.getInstance(firebaseApp).sendEachForMulticast(multicastMessage);
         } catch (FirebaseMessagingException e) {
             throw new PushNotiException();
         }


### PR DESCRIPTION
## PR 타입

## 개요
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/52ef55e4-a311-4a6e-af77-65eb08ea5f62">
- FCM 에서 서비스 중단한 API라서 동일한 기능을 하는 다른 API 로 변경(푸시 알림 발송 시에 에러 로그가 발생하고 알림 발송이 되지 않음)

##  변경사항

