### PR TITLE
feat: 멤버의 최신 기수를 조회하여 가져오도록 수정

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustom.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface MemberGenerationRepositoryCustom {
     Optional<MemberGeneration> findByMemberIdAndGenerationNumber(Long memberId, Integer generationNumber);
 
     List<MemberGeneration> findByMemberIdsAndGenerationNumber(List<Long> memberIds, Integer generationNumber);
+
+    Optional<MemberGeneration> findLatestByMemberId(Long memberId);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberGenerationRepositoryCustomImpl.java
@@ -35,4 +35,16 @@ public class MemberGenerationRepositoryCustomImpl implements MemberGenerationRep
             .where(member.id.in(memberIds), generation.number.eq(generationNumber))
             .fetch();
     }
+
+    public Optional<MemberGeneration> findLatestByMemberId(Long memberId) {
+        return Optional.ofNullable(queryFactory
+            .selectFrom(memberGeneration)
+            .join(memberGeneration.member, member)
+            .join(memberGeneration.generation, generation)
+            .where(member.id.eq(memberId))
+            .orderBy(generation.number.desc())
+            .limit(1)
+            .fetchFirst()
+        );
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -4,6 +4,7 @@ import kr.mashup.branding.domain.BaseEntity;
 import kr.mashup.branding.domain.ResultCode;
 import kr.mashup.branding.domain.exception.BadRequestException;
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
+import kr.mashup.branding.domain.exception.NotFoundException;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
@@ -340,7 +341,12 @@ public class MemberService {
             .forEach(MemberGeneration::dropOut);
     }
 
-    public MemberGeneration getCurrentMemberGeneration(Member member) {
+    public MemberGeneration getLatestMemberGeneration(long memberId) {
+        return memberGenerationRepository.findLatestByMemberId(memberId)
+            .orElseThrow(NotFoundException::new);
+    }
+
+    public MemberGeneration getLatestMemberGeneration(Member member) {
         return member.getMemberGenerations()
             .stream()
             .max(Comparator.comparingInt(mg -> mg.getGeneration().getNumber()))

--- a/mashup-member/src/main/java/kr/mashup/branding/config/web/MemberAuthArgumentResolver.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/config/web/MemberAuthArgumentResolver.java
@@ -3,10 +3,12 @@ package kr.mashup.branding.config.web;
 import kr.mashup.branding.domain.exception.UnauthorizedException;
 import kr.mashup.branding.security.JwtService;
 import kr.mashup.branding.security.MemberAuth;
+import kr.mashup.branding.service.member.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -21,6 +23,7 @@ import java.util.Map;
 public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final JwtService jwtService;
+    private final MemberService memberService;
     public static final String MDC_MEMBER_ID = "memberId";
 
     @Override
@@ -30,20 +33,33 @@ public class MemberAuthArgumentResolver implements HandlerMethodArgumentResolver
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        String authorization = webRequest.getHeader("Authorization");
-        //Assert.notNull(authorization, "Authorization Header must be not null");
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            throw new UnauthorizedException();
-        }
-        String token = authorization.substring(7);
+        String token = extractTokenFromHeader(webRequest);
         Map<String, Long> decodedToken = jwtService.decode(token);
-        Long memberId = decodedToken.get(JwtService.CLAIM_NAME_MEMBER_ID);
-        Long memberGenerationId = decodedToken.get(JwtService.CLAIM_NAME_MEMBER_GENERATION_ID);
-        if (memberId == null || memberGenerationId == null) {
-            throw new UnauthorizedException();
-        }
+
+        Long memberId = getMemberId(decodedToken);
+        Long memberGenerationId = getMemberGenerationId(memberId);
 
         MDC.put(MDC_MEMBER_ID, String.valueOf(memberId));
         return MemberAuth.of(memberId, memberGenerationId);
+    }
+
+    private String extractTokenFromHeader(NativeWebRequest webRequest) {
+        String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new UnauthorizedException();
+        }
+        return authorization.substring(7);
+    }
+
+    private Long getMemberId(Map<String, Long> decodedToken) {
+        Long memberId = decodedToken.get(JwtService.CLAIM_NAME_MEMBER_ID);
+        if (memberId == null) {
+            throw new UnauthorizedException();
+        }
+        return memberId;
+    }
+
+    private Long getMemberGenerationId(long memberId) {
+        return memberService.getLatestMemberGeneration(memberId).getId();
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayCardFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/birthday/BirthdayCardFacadeService.java
@@ -53,7 +53,7 @@ public class BirthdayCardFacadeService {
     @Transactional
     public void send(Long memberId, BirthdayCardRequest request) {
         Member senderMember = memberService.findMemberById(memberId);
-        MemberGeneration latestMemberGeneration = memberService.getCurrentMemberGeneration(senderMember);
+        MemberGeneration latestMemberGeneration = memberService.getLatestMemberGeneration(senderMember);
 
         birthdayCardService.checkAlreadySent(request.getRecipientMemberId(), senderMember, latestMemberGeneration);
         birthdayCardService.send(request.getRecipientMemberId(), senderMember, latestMemberGeneration, request.getMessage(), request.getImageUrl());
@@ -62,7 +62,7 @@ public class BirthdayCardFacadeService {
     @Transactional(readOnly = true)
     public BirthdayCardsResponse getMy(Long memberId) {
         Member member = memberService.findMemberById(memberId);
-        MemberGeneration generation = memberService.getCurrentMemberGeneration(member);
+        MemberGeneration generation = memberService.getLatestMemberGeneration(member);
 
         List<BirthdayCardResponse> birthdayCards = birthdayCardService.getMy(member, generation)
             .stream()

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/member/MemberFacadeService.java
@@ -1,12 +1,5 @@
 package kr.mashup.branding.facade.member;
 
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kr.mashup.branding.domain.exception.GenerationIntegrityFailException;
 import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.invite.Invite;
@@ -16,24 +9,19 @@ import kr.mashup.branding.domain.member.Platform;
 import kr.mashup.branding.domain.member.exception.MemberInvalidInviteCodeException;
 import kr.mashup.branding.domain.scorehistory.ScoreHistory;
 import kr.mashup.branding.domain.scorehistory.ScoreType;
-import kr.mashup.branding.service.member.MemberCreateDto;
 import kr.mashup.branding.security.JwtService;
 import kr.mashup.branding.service.invite.InviteService;
+import kr.mashup.branding.service.member.MemberCreateDto;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.scorehistory.ScoreHistoryService;
-import kr.mashup.branding.ui.member.request.LoginRequest;
-import kr.mashup.branding.ui.member.request.MemberGenerationRequest;
-import kr.mashup.branding.ui.member.request.MemberPasswordChangeRequest;
-import kr.mashup.branding.ui.member.request.PushNotificationRequest;
-import kr.mashup.branding.ui.member.request.SignUpRequest;
-import kr.mashup.branding.ui.member.request.ValidInviteRequest;
-import kr.mashup.branding.ui.member.response.AccessResponse;
-import kr.mashup.branding.ui.member.response.ExistsResponse;
-import kr.mashup.branding.ui.member.response.MemberGenerationsResponse;
-import kr.mashup.branding.ui.member.response.MemberInfoResponse;
-import kr.mashup.branding.ui.member.response.TokenResponse;
-import kr.mashup.branding.ui.member.response.ValidResponse;
+import kr.mashup.branding.ui.member.request.*;
+import kr.mashup.branding.ui.member.response.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Service
@@ -121,8 +109,8 @@ public class MemberFacadeService {
         memberService.deleteMember(memberId);
     }
 
-    public TokenResponse getAccessToken(Long memberId, Long memberGenerationId) {
-        final String token = jwtService.encode(memberId, memberGenerationId);
+    public TokenResponse getAccessToken(Long memberId) {
+        final String token = jwtService.encode(memberId);
         return TokenResponse.of(token);
     }
 
@@ -175,15 +163,8 @@ public class MemberFacadeService {
         memberService.resetPassword(identification, request.getNewPassword());
     }
 
-    private MemberGeneration getLatestMemberGeneration(Member member) {
-        return member.getMemberGenerations().stream().max(Comparator.comparing(
-            memberGeneration -> memberGeneration.getGeneration().getNumber()
-        )).orElseThrow(GenerationIntegrityFailException::new);
-    }
-
     private String getToken(Member member) {
-        final MemberGeneration latestMemberGeneration = getLatestMemberGeneration(member);
-        return jwtService.encode(member.getId(), latestMemberGeneration.getId());
+        return jwtService.encode(member.getId());
     }
 
     private void checkMemberGenerationIsIn(Long memberGenerationId, List<MemberGeneration> memberGenerations) {

--- a/mashup-member/src/main/java/kr/mashup/branding/security/JwtService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/security/JwtService.java
@@ -22,12 +22,11 @@ public class JwtService {
     private String secretKey;
 
     public static final String CLAIM_NAME_MEMBER_ID = "MemberId";
-    public static final String CLAIM_NAME_MEMBER_GENERATION_ID = "MemberGenerationId";
 
     private Algorithm algorithm;
     private JWTVerifier jwtVerifier;
 
-    public String encode(Long memberId, Long memberGenerationId) {
+    public String encode(Long memberId) {
 
         LocalDateTime expiredAt = LocalDateTime.now().plusWeeks(4L);
 
@@ -35,7 +34,6 @@ public class JwtService {
 
         return JWT.create()
             .withClaim(CLAIM_NAME_MEMBER_ID, memberId)
-            .withClaim(CLAIM_NAME_MEMBER_GENERATION_ID, memberGenerationId)
             .withExpiresAt(date)
             .sign(algorithm);
     }
@@ -43,10 +41,7 @@ public class JwtService {
     public Map<String, Long> decode(String token) {
         try {
             DecodedJWT jwt = jwtVerifier.verify(token);
-            return Map.of(
-                CLAIM_NAME_MEMBER_ID, jwt.getClaim(CLAIM_NAME_MEMBER_ID).asLong(),
-                CLAIM_NAME_MEMBER_GENERATION_ID, jwt.getClaim(CLAIM_NAME_MEMBER_GENERATION_ID).asLong()
-            );
+            return Map.of(CLAIM_NAME_MEMBER_ID, jwt.getClaim(CLAIM_NAME_MEMBER_ID).asLong());
         } catch (JWTVerificationException e) {
             log.warn("Failed to decode jwt. token: {}", token, e);
             throw new UnauthorizedException();

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberController.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/member/MemberController.java
@@ -104,7 +104,7 @@ public class MemberController {
             @ApiIgnore MemberAuth memberAuth
     ) {
         final TokenResponse tokenResponse
-                = memberFacadeService.getAccessToken(memberAuth.getMemberId(), memberAuth.getMemberGenerationId());
+                = memberFacadeService.getAccessToken(memberAuth.getMemberId());
 
         return ApiResponse.success(tokenResponse);
     }


### PR DESCRIPTION
## PR 타입

## 개요
- 토큰 페이로드에서 멤버의 최신 기수 제거(다음 기수를 이어서 하는 멤버의 경우, 토큰이 발급된 시점의 기수와 그 다음 기수가 맞지 않아서 기수 재시작시에 재로그인이 필요한 불편함이 있음)
- MemberAuth 객체의 멤버의 최신 기수 필드는 조회하여 가져오도록 수정

##  변경사항

