### PR TITLE
feat: 출석 마감 시 플랫폼 리더에게 지각자/결석자 푸시 알림

### DIFF
--- a/docs/attendance-leader-notification-prd.md
+++ b/docs/attendance-leader-notification-prd.md
@@ -1,0 +1,108 @@
+# PRD: 플랫폼 리더 출석 알림
+
+## 1. 배경
+
+현재 출석 체크 시스템은 멤버 개인에게만 알림을 보낸다 (출석 시작 전, 시작 시, 마감 임박).
+출석 시간이 끝난 후 **누가 지각/결석했는지 플랫폼 리더가 파악할 수 있는 수단이 없다.**
+
+## 2. 목표
+
+출석/지각 마감 시점에 각 플랫폼 리더에게 해당 플랫폼의 지각자/결석자 명단을 FCM 푸시 알림으로 발송한다.
+
+## 3. 사용자 시나리오
+
+```
+14:00  출석 체크 시작 (attendanceCheckStartedAt)
+14:10  출석 체크 마감 (attendanceCheckEndedAt)
+       → 리더에게 푸시: "Spring 지각자: 홍길동, 김철수"
+       
+14:20  지각 체크 마감 (latenessCheckEndedAt)
+       → 리더에게 푸시: "Spring 결석자: 홍길동"
+```
+
+- 해당 플랫폼에 지각자/결석자가 없으면 발송하지 않는다.
+
+## 4. 기능 요구사항
+
+### 4.1 리더 식별
+
+- `AdminMember` 엔티티에 `memberId` (Long, nullable) 컬럼을 추가한다.
+- `AdminMember.memberId` → `Member.id` 참조로 운영진 계정과 멤버 계정을 연결한다.
+- 리더 대상: `Position`이 `*_LEADER` 또는 `*_SUBLEADER`인 AdminMember.
+- 각 Position의 `Team[] authorities`로 담당 플랫폼을 식별한다.
+- `MASHUP_LEADER`, `MASHUP_SUBLEADER`는 모든 플랫폼 알림을 수신한다.
+
+### 4.2 알림 1: 지각자 알림
+
+- **트리거**: `attendanceCheckEndedAt` 경과 시점
+- **대상**: 출석 마감까지 체크하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
+- **제목**: "출석 현황 알림"
+- **본문**: "{플랫폼명} 지각자: {이름1}, {이름2}, ..."
+
+### 4.3 알림 2: 결석자 알림
+
+- **트리거**: `latenessCheckEndedAt` 경과 시점
+- **대상**: 지각 마감까지도 체크하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
+- **제목**: "출석 현황 알림"
+- **본문**: "{플랫폼명} 결석자: {이름1}, {이름2}, ..."
+
+### 4.4 공통 사항
+
+- 기존 `@Scheduled(cron = "0 * * * * *")` 패턴을 따라 매분 체크한다.
+- 기존 FCM 인프라 (`PushNotiEventPublisher` → `PushNotiEventListener`) 활용.
+- 딥링크: `MAIN`
+- `AdminMember.memberId`가 null이면 해당 리더에게는 발송하지 않는다.
+- 해당 플랫폼에 지각자/결석자가 0명이면 발송하지 않는다.
+
+## 5. 시간 흐름과 알림 관계
+
+```
+ attendanceCheckStartedAt        attendanceCheckEndedAt        latenessCheckEndedAt
+         │                                │                            │
+         ├── 출석 인정 구간 ──────────────┤── 지각 인정 구간 ──────────┤
+         │                                │                            │
+         │  QR 체크 → 출석               │  QR 체크 → 지각            │  이후 → 결석
+         │                                │                            │
+         │  [기존] 시작 알림 (멤버)       │  ★ 지각자 알림 (리더)      │  ★ 결석자 알림 (리더)
+```
+
+## 6. 영향 범위
+
+### mashup-domain (공유 도메인)
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `AdminMember.java` | 수정 | `memberId` (Long, nullable) 컬럼 추가 |
+| `Position.java` | 수정 | `isLeaderOrSubLeader()`, `toPlatform(Team)` 헬퍼 메서드 추가 |
+| `AdminMemberRepository.java` | 수정 | `findAllByPositionInAndMemberIdIsNotNull()` 쿼리 추가 |
+| `AdminMemberService.java` | 수정 | `getLeadersWithMemberId()` 메서드 추가 |
+| `AttendanceCodeRepository.java` | 수정 | `latenessCheckEndedAt` 범위 쿼리 추가 |
+| `AttendanceCodeService.java` | 수정 | `findAllByLatenessEndedAtLeftOpenBetween()` 래핑 메서드 추가 |
+| `AttendanceLateForLeaderVo.java` | **신규** | 지각자 알림 VO (동적 body: "{플랫폼} 지각자: {이름들}") |
+| `AttendanceAbsentForLeaderVo.java` | **신규** | 결석자 알림 VO (동적 body: "{플랫폼} 결석자: {이름들}") |
+
+### mashup-member (멤버 API 서버)
+
+| 파일 | 변경 | 내용 |
+|------|------|------|
+| `AttendanceFacadeService.java` | 수정 | `sendLateNotiToLeaders()` 스케줄러 (출석 마감 시점) |
+|  |  | `sendAbsentNotiToLeaders()` 스케줄러 (지각 마감 시점) |
+|  |  | `sendLeaderNotiByPlatform()` 플랫폼별 집계/발송 공통 로직 |
+|  |  | `getLeaderMembersForPlatform()` Position→Platform 매핑 조회 |
+|  |  | `findAllLatenessEndsWithin()` 시간 범위 헬퍼 |
+
+## 7. 데이터 모델 변경
+
+```sql
+ALTER TABLE admin_member ADD COLUMN member_id BIGINT NULL;
+```
+
+운영진 계정과 멤버 계정을 연결하기 위한 컬럼. 
+관리자 생성/수정 시 해당 운영진의 Member ID를 수동으로 연결해야 한다.
+
+## 8. 범위 외 (Out of Scope)
+
+- Discord/Slack 웹훅 연동
+- 출석 완료 시 본인에게 보내는 푸시
+- 관리자 화면에서 memberId 연결 UI
+- 기존 멤버 대상 출석 알림 (Starting, Started, Ending) 변경

--- a/docs/attendance-leader-notification-prd.md
+++ b/docs/attendance-leader-notification-prd.md
@@ -3,24 +3,30 @@
 ## 1. 배경
 
 현재 출석 체크 시스템은 멤버 개인에게만 알림을 보낸다 (출석 시작 전, 시작 시, 마감 임박).
-출석 시간이 끝난 후 **누가 지각/결석했는지 플랫폼 리더가 파악할 수 있는 수단이 없다.**
+QR 출석을 깜빡하거나 실수로 놓치는 멤버가 있어도, **플랫폼 리더가 마감 전에 파악하고 독려할 수 있는 수단이 없다.**
 
 ## 2. 목표
 
-출석/지각 마감 시점에 각 플랫폼 리더에게 해당 플랫폼의 지각자/결석자 명단을 FCM 푸시 알림으로 발송한다.
+출석/지각 마감 **N분 전**에 각 플랫폼 리더에게 아직 출석하지 않은 멤버 명단을 FCM 푸시로 발송하여,
+리더가 마감 전에 해당 멤버에게 출석을 독려할 수 있도록 한다.
 
 ## 3. 사용자 시나리오
 
 ```
+설정: LEADER_NOTI_BEFORE_MINUTES=3 (환경변수)
+
 14:00  출석 체크 시작 (attendanceCheckStartedAt)
+14:07  ★ 리더에게 푸시: "Spring에서 아직 출석하지 않은 멤버가 있어요: 홍길동, 김철수"
+       (출석 마감 3분 전, 리더가 홍길동/김철수에게 직접 연락)
 14:10  출석 체크 마감 (attendanceCheckEndedAt)
-       → 리더에게 푸시: "Spring 지각자: 홍길동, 김철수"
-       
+
+14:17  ★ 리더에게 푸시: "Spring에서 출석하지 못한 멤버가 있어요: 홍길동"
+       (지각 마감 3분 전, 마지막 기회 독려)
 14:20  지각 체크 마감 (latenessCheckEndedAt)
-       → 리더에게 푸시: "Spring 결석자: 홍길동"
 ```
 
-- 해당 플랫폼에 지각자/결석자가 없으면 발송하지 않는다.
+- 마감 N분 전 시점에 미출석자가 없으면 발송하지 않는다.
+- N은 환경변수로 설정 가능하며, 기본값은 3분이다.
 
 ## 4. 기능 요구사항
 
@@ -32,41 +38,59 @@
 - 각 Position의 `Team[] authorities`로 담당 플랫폼을 식별한다.
 - `MASHUP_LEADER`, `MASHUP_SUBLEADER`는 모든 플랫폼 알림을 수신한다.
 
-### 4.2 알림 1: 지각자 알림
+### 4.2 알림 1: 지각 예정자 알림 (출석 마감 N분 전)
 
-- **트리거**: `attendanceCheckEndedAt` 경과 시점
-- **대상**: 출석 마감까지 체크하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
+- **트리거**: `attendanceCheckEndedAt` N분 전 시점
+- **대상**: 아직 출석하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
 - **제목**: "출석 현황 알림"
-- **본문**: "{플랫폼명} 지각자: {이름1}, {이름2}, ..."
+- **본문**: "{플랫폼명}에서 아직 출석하지 않은 멤버가 있어요: {이름1}, {이름2}, ..."
+- **목적**: 리더가 마감 전에 해당 멤버에게 출석을 독려
 
-### 4.3 알림 2: 결석자 알림
+### 4.3 알림 2: 결석 예정자 알림 (지각 마감 N분 전)
 
-- **트리거**: `latenessCheckEndedAt` 경과 시점
-- **대상**: 지각 마감까지도 체크하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
+- **트리거**: `latenessCheckEndedAt` N분 전 시점
+- **대상**: 아직 출석/지각 체크를 하지 않은 멤버 명단 → 해당 플랫폼 리더에게 발송
 - **제목**: "출석 현황 알림"
-- **본문**: "{플랫폼명} 결석자: {이름1}, {이름2}, ..."
+- **본문**: "{플랫폼명}에서 출석하지 못한 멤버가 있어요: {이름1}, {이름2}, ..."
+- **목적**: 마감 직전 마지막 독려 기회 제공
 
-### 4.4 공통 사항
+### 4.4 N분 전 설정
+
+- 환경변수: `attendance.leader-noti.before-minutes` (application.yml)
+- 기본값: `3` (분)
+- 값을 `0`으로 설정하면 마감 시점에 발송 (기존 동작과 동일)
+
+### 4.5 공통 사항
 
 - 기존 `@Scheduled(cron = "0 * * * * *")` 패턴을 따라 매분 체크한다.
 - 기존 FCM 인프라 (`PushNotiEventPublisher` → `PushNotiEventListener`) 활용.
 - 딥링크: `MAIN`
 - `AdminMember.memberId`가 null이면 해당 리더에게는 발송하지 않는다.
-- 해당 플랫폼에 지각자/결석자가 0명이면 발송하지 않는다.
+- 해당 플랫폼에 미출석자가 0명이면 발송하지 않는다.
 
-## 5. 시간 흐름과 알림 관계
+## 5. 시간 흐름과 알림 관계 (N=3분 예시)
 
 ```
- attendanceCheckStartedAt        attendanceCheckEndedAt        latenessCheckEndedAt
-         │                                │                            │
-         ├── 출석 인정 구간 ──────────────┤── 지각 인정 구간 ──────────┤
-         │                                │                            │
-         │  QR 체크 → 출석               │  QR 체크 → 지각            │  이후 → 결석
-         │                                │                            │
-         │  [기존] 시작 알림 (멤버)       │  ★ 지각자 알림 (리더)      │  ★ 결석자 알림 (리더)
+ attendanceCheckStartedAt     attendanceCheckEndedAt        latenessCheckEndedAt
+         │                          │                            │
+         ├── 출석 인정 구간 ────────┤── 지각 인정 구간 ──────────┤
+         │                          │                            │
+         │  QR 체크 → 출석         │  QR 체크 → 지각            │  이후 → 결석
+         │                          │                            │
+         │              ★ 지각예정 알림(N분전)      ★ 결석예정 알림(N분전)
+         │              (리더가 독려)               (마지막 기회)
 ```
 
-## 6. 영향 범위
+## 6. 설정
+
+```yaml
+# application.yml
+attendance:
+  leader-noti:
+    before-minutes: 3
+```
+
+## 7. 영향 범위
 
 ### mashup-domain (공유 도메인)
 
@@ -76,31 +100,28 @@
 | `Position.java` | 수정 | `isLeaderOrSubLeader()`, `toPlatform(Team)` 헬퍼 메서드 추가 |
 | `AdminMemberRepository.java` | 수정 | `findAllByPositionInAndMemberIdIsNotNull()` 쿼리 추가 |
 | `AdminMemberService.java` | 수정 | `getLeadersWithMemberId()` 메서드 추가 |
-| `AttendanceCodeRepository.java` | 수정 | `latenessCheckEndedAt` 범위 쿼리 추가 |
-| `AttendanceCodeService.java` | 수정 | `findAllByLatenessEndedAtLeftOpenBetween()` 래핑 메서드 추가 |
-| `AttendanceLateForLeaderVo.java` | **신규** | 지각자 알림 VO (동적 body: "{플랫폼} 지각자: {이름들}") |
-| `AttendanceAbsentForLeaderVo.java` | **신규** | 결석자 알림 VO (동적 body: "{플랫폼} 결석자: {이름들}") |
+| `AttendanceCodeRepository.java` | 수정 | `attendanceCheckEndedAt`, `latenessCheckEndedAt` 범위 쿼리 |
+| `AttendanceCodeService.java` | 수정 | 래핑 메서드 추가 |
+| `AttendanceLateForLeaderVo.java` | **신규** | 지각 예정자 알림 VO |
+| `AttendanceAbsentForLeaderVo.java` | **신규** | 결석 예정자 알림 VO |
+| `MemberService.java` | 수정 | 예외 없는 배치 조회 `findAllByIds()` 추가 |
 
 ### mashup-member (멤버 API 서버)
 
 | 파일 | 변경 | 내용 |
 |------|------|------|
-| `AttendanceFacadeService.java` | 수정 | `sendLateNotiToLeaders()` 스케줄러 (출석 마감 시점) |
-|  |  | `sendAbsentNotiToLeaders()` 스케줄러 (지각 마감 시점) |
-|  |  | `sendLeaderNotiByPlatform()` 플랫폼별 집계/발송 공통 로직 |
-|  |  | `getLeaderMembersForPlatform()` Position→Platform 매핑 조회 |
-|  |  | `findAllLatenessEndsWithin()` 시간 범위 헬퍼 |
+| `AttendanceFacadeService.java` | 수정 | 스케줄러 2개 + 리더 푸시 로직 + N분 전 설정 주입 |
 
-## 7. 데이터 모델 변경
+## 8. 데이터 모델 변경
 
 ```sql
 ALTER TABLE admin_member ADD COLUMN member_id BIGINT NULL;
 ```
 
-운영진 계정과 멤버 계정을 연결하기 위한 컬럼. 
+운영진 계정과 멤버 계정을 연결하기 위한 컬럼.
 관리자 생성/수정 시 해당 운영진의 Member ID를 수동으로 연결해야 한다.
 
-## 8. 범위 외 (Out of Scope)
+## 9. 범위 외 (Out of Scope)
 
 - Discord/Slack 웹훅 연동
 - 출석 완료 시 본인에게 보내는 푸시

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/adminmember/entity/AdminMember.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/adminmember/entity/AdminMember.java
@@ -30,6 +30,9 @@ public class AdminMember {
     @Enumerated(EnumType.STRING)
     private Position position;
 
+    @Column(name = "member_id")
+    private Long memberId;
+
     @CreatedBy
     private String createdBy;
 

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/adminmember/entity/Position.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/adminmember/entity/Position.java
@@ -1,5 +1,6 @@
 package kr.mashup.branding.domain.adminmember.entity;
 
+import kr.mashup.branding.domain.member.Platform;
 import lombok.Getter;
 
 @Getter
@@ -39,6 +40,15 @@ public enum Position {
 
     Position(Team... authorities) {
         this.authorities = authorities;
+    }
+
+    public boolean isLeaderOrSubLeader() {
+        return this.name().endsWith("_LEADER") || this.name().endsWith("_SUBLEADER");
+    }
+
+    public static Platform toPlatform(Team team) {
+        if (team == Team.iOS) return Platform.IOS;
+        return Platform.valueOf(team.name());
     }
 
     @Getter

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceAbsentForLeaderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceAbsentForLeaderVo.java
@@ -1,0 +1,19 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import java.util.List;
+import java.util.Map;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+public class AttendanceAbsentForLeaderVo extends PushNotiSendVo {
+    private static final PushType pushType = PushType.ATTENDANCE;
+    private static final String title = "출석 현황 알림";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
+
+    public AttendanceAbsentForLeaderVo(List<Member> leaders, String platformName, String absentNames) {
+        super(leaders, pushType, title,
+              platformName + "에서 출석하지 못한 멤버가 있어요: " + absentNames, dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceLateForLeaderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceLateForLeaderVo.java
@@ -1,0 +1,19 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import java.util.List;
+import java.util.Map;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+public class AttendanceLateForLeaderVo extends PushNotiSendVo {
+    private static final PushType pushType = PushType.ATTENDANCE;
+    private static final String title = "출석 현황 알림";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
+
+    public AttendanceLateForLeaderVo(List<Member> leaders, String platformName, String lateNames) {
+        super(leaders, pushType, title,
+              platformName + "에서 아직 출석하지 않은 멤버가 있어요: " + lateNames, dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/adminmember/AdminMemberRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/adminmember/AdminMemberRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import kr.mashup.branding.domain.adminmember.entity.AdminMember;
+import kr.mashup.branding.domain.adminmember.entity.Position;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminMemberRepository extends JpaRepository<AdminMember, Long> {
@@ -12,4 +13,6 @@ public interface AdminMemberRepository extends JpaRepository<AdminMember, Long> 
     boolean existsByUsername(String username);
 
     List<AdminMember> findAdminMembersByAdminMemberIdIn(List<Long> adminMemberIds);
+
+    List<AdminMember> findAllByPositionInAndMemberIdIsNotNull(List<Position> positions);
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/attendancecode/AttendanceCodeRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/attendancecode/AttendanceCodeRepository.java
@@ -16,6 +16,8 @@ public interface AttendanceCodeRepository extends JpaRepository<AttendanceCode, 
     List<AttendanceCode> findAllByAttendanceCheckStartedAtGreaterThanAndAttendanceCheckStartedAtLessThanEqual(LocalDateTime from, LocalDateTime to);
 
     List<AttendanceCode> findAllByAttendanceCheckEndedAtGreaterThanAndAttendanceCheckEndedAtLessThanEqual(LocalDateTime from, LocalDateTime to);
+
+    List<AttendanceCode> findAllByLatenessCheckEndedAtGreaterThanAndLatenessCheckEndedAtLessThanEqual(LocalDateTime from, LocalDateTime to);
 }
 /**
  * AttendanceCode 연관관계

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/adminmember/AdminMemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/adminmember/AdminMemberService.java
@@ -1,6 +1,7 @@
 package kr.mashup.branding.service.adminmember;
 
 import kr.mashup.branding.domain.adminmember.entity.AdminMember;
+import kr.mashup.branding.domain.adminmember.entity.Position;
 import kr.mashup.branding.domain.adminmember.exception.AdminMemberLoginFailedException;
 import kr.mashup.branding.domain.adminmember.exception.AdminMemberNotFoundException;
 import kr.mashup.branding.domain.adminmember.exception.AdminMemberUsernameDuplicatedException;
@@ -16,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import javax.transaction.Transactional;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Validated
 @RequiredArgsConstructor
@@ -135,5 +138,12 @@ public class AdminMemberService {
 
     public List<AdminMember> readAdminMembers() {
         return adminMemberRepository.findAll();
+    }
+
+    public List<AdminMember> getLeadersWithMemberId() {
+        List<Position> leaderPositions = Arrays.stream(Position.values())
+            .filter(Position::isLeaderOrSubLeader)
+            .collect(Collectors.toList());
+        return adminMemberRepository.findAllByPositionInAndMemberIdIsNotNull(leaderPositions);
     }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/attendance/AttendanceCodeService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/attendance/AttendanceCodeService.java
@@ -29,4 +29,8 @@ public class AttendanceCodeService {
     public List<AttendanceCode> findAllByEndedAtLeftOpenBetween(LocalDateTime from, LocalDateTime to) {
         return attendanceCodeRepository.findAllByAttendanceCheckEndedAtGreaterThanAndAttendanceCheckEndedAtLessThanEqual(from, to);
     }
+
+    public List<AttendanceCode> findAllByLatenessEndedAtLeftOpenBetween(LocalDateTime from, LocalDateTime to) {
+        return attendanceCodeRepository.findAllByLatenessCheckEndedAtGreaterThanAndLatenessCheckEndedAtLessThanEqual(from, to);
+    }
 }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/member/MemberService.java
@@ -314,6 +314,10 @@ public class MemberService {
         return members;
     }
 
+    public List<Member> findAllByIds(final List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
+    }
+
     @Transactional
     public void transfer(final Generation oldGeneration, final Generation newGeneration, final List<Member> members) {
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -33,6 +33,7 @@ import kr.mashup.branding.ui.attendance.response.*;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +53,10 @@ public class AttendanceFacadeService {
     private final static long ATTENDANCE_START_AFTER_MINUTES = 1;
     private final static long ATTENDANCE_END_AFTER_MINUTES = 3;
     private final static double ATTENDANCE_DISTANCE = 1000;
+
+    @Value("${attendance.leader-noti.before-minutes:3}")
+    private long leaderNotiBeforeMinutes;
+
     private final AttendanceService attendanceService;
     private final MemberService memberService;
     private final ScheduleService scheduleService;
@@ -190,21 +195,21 @@ public class AttendanceFacadeService {
     }
 
     /**
-     * 출석 마감 시점: 플랫폼 리더에게 지각자 명단 푸시
+     * 출석 마감 N분 전: 플랫폼 리더에게 미출석자 명단 푸시
      */
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceLatePushNotiToLeaders() {
-        sendLeaderPushNoti(findAllEndsWithin(0L), AttendanceLateForLeaderVo::new);
+        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new);
     }
 
     /**
-     * 지각 마감 시점: 플랫폼 리더에게 결석자 명단 푸시
+     * 지각 마감 N분 전: 플랫폼 리더에게 미출석자 명단 푸시
      */
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceAbsentPushNotiToLeaders() {
-        sendLeaderPushNoti(findAllLatenessEndsWithin(0L), AttendanceAbsentForLeaderVo::new);
+        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new);
     }
 
     private void sendLeaderPushNoti(

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -11,13 +11,19 @@ import kr.mashup.branding.domain.generation.Generation;
 import kr.mashup.branding.domain.member.Member;
 import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.Platform;
+import kr.mashup.branding.domain.adminmember.entity.AdminMember;
+import kr.mashup.branding.domain.adminmember.entity.Position;
+import kr.mashup.branding.domain.pushnoti.vo.AttendanceAbsentForLeaderVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceEndingVo;
+import kr.mashup.branding.domain.pushnoti.vo.AttendanceLateForLeaderVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartedVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartingVo;
+import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
 import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
+import kr.mashup.branding.service.adminmember.AdminMemberService;
 import kr.mashup.branding.service.attendance.AttendanceCodeService;
 import kr.mashup.branding.service.attendance.AttendanceService;
 import kr.mashup.branding.service.member.MemberService;
@@ -34,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -50,6 +57,7 @@ public class AttendanceFacadeService {
     private final ScheduleService scheduleService;
     private final AttendanceCodeService attendanceCodeService;
     private final PushNotiEventPublisher pushNotiEventPublisher;
+    private final AdminMemberService adminMemberService;
 
     /**
      * 출석 체크
@@ -181,6 +189,111 @@ public class AttendanceFacadeService {
         );
     }
 
+    /**
+     * 출석 마감 시점: 플랫폼 리더에게 지각자 명단 푸시
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional(readOnly = true)
+    public void sendAttendanceLatePushNotiToLeaders() {
+        sendLeaderPushNoti(findAllEndsWithin(0L), AttendanceLateForLeaderVo::new);
+    }
+
+    /**
+     * 지각 마감 시점: 플랫폼 리더에게 결석자 명단 푸시
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional(readOnly = true)
+    public void sendAttendanceAbsentPushNotiToLeaders() {
+        sendLeaderPushNoti(findAllLatenessEndsWithin(0L), AttendanceAbsentForLeaderVo::new);
+    }
+
+    private void sendLeaderPushNoti(
+            final List<AttendanceCode> attendanceCodes,
+            final LeaderNotiVoFactory voFactory
+    ) {
+        if (attendanceCodes.isEmpty()) return;
+
+        final Map<Platform, List<Member>> leadersByPlatform = resolveLeadersByPlatform();
+
+        for (AttendanceCode attendanceCode : attendanceCodes) {
+            final Event event = attendanceCode.getEvent();
+            final Schedule schedule = event.getSchedule();
+            final Generation generation = schedule.getGeneration();
+
+            final List<Member> checkedMembers = attendanceService.getByEvent(event).stream()
+                    .map(Attendance::getMember)
+                    .collect(Collectors.toList());
+
+            for (Platform platform : Platform.values()) {
+                if (!schedule.checkAvailabilityByPlatform(platform)) continue;
+
+                final List<Member> platformMembers =
+                        memberService.getAllByPlatformAndGeneration(platform, generation);
+
+                final List<Member> notCheckedMembers = new ArrayList<>(platformMembers);
+                notCheckedMembers.removeAll(checkedMembers);
+
+                if (notCheckedMembers.isEmpty()) continue;
+
+                final List<Member> leaderMembers = leadersByPlatform.getOrDefault(platform, Collections.emptyList());
+                if (leaderMembers.isEmpty()) continue;
+
+                final String names = formatNames(notCheckedMembers);
+
+                pushNotiEventPublisher.publishPushNotiSendEvent(
+                        voFactory.create(leaderMembers, platform.getName(), names));
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface LeaderNotiVoFactory {
+        PushNotiSendVo create(List<Member> leaders, String platformName, String names);
+    }
+
+    private Map<Platform, List<Member>> resolveLeadersByPlatform() {
+        final List<AdminMember> leaders = adminMemberService.getLeadersWithMemberId();
+        if (leaders.isEmpty()) return Collections.emptyMap();
+
+        final List<Long> memberIds = leaders.stream()
+                .map(AdminMember::getMemberId)
+                .collect(Collectors.toList());
+        final Map<Long, Member> memberMap = memberService.findAllByIds(memberIds).stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        final Map<Platform, List<Member>> result = new HashMap<>();
+        for (AdminMember admin : leaders) {
+            final Member member = memberMap.get(admin.getMemberId());
+            if (member == null) {
+                log.warn("[LEADER_NOTI] member not found for adminMemberId={}, memberId={}",
+                        admin.getAdminMemberId(), admin.getMemberId());
+                continue;
+            }
+            for (Position.Team team : admin.getPosition().getAuthorities()) {
+                final Platform platform = Position.toPlatform(team);
+                result.computeIfAbsent(platform, k -> new ArrayList<>()).add(member);
+            }
+        }
+        return result;
+    }
+
+    private String formatNames(List<Member> members) {
+        final List<String> nameList = members.stream()
+                .map(Member::getName)
+                .collect(Collectors.toList());
+        if (nameList.size() > 20) {
+            return String.join(", ", nameList.subList(0, 20)) + " 외 " + (nameList.size() - 20) + "명";
+        }
+        return String.join(", ", nameList);
+    }
+
+    private List<AttendanceCode> findAllLatenessEndsWithin(Long afterMinutes) {
+        final LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        return attendanceCodeService.findAllByLatenessEndedAtLeftOpenBetween(
+                now.plusMinutes(-PUSH_SCHEDULE_INTERVAL_MINUTES + afterMinutes),
+                now.plusMinutes(afterMinutes)
+        );
+    }
 
     /**
      * 이미 출석 체크를 했는지 판별


### PR DESCRIPTION
## PR 타입
Feature

## 개요
출석/지각 마감 **N분 전**에 각 플랫폼 리더에게 미출석자 명단을 FCM 푸시 알림으로 발송하여,
리더가 마감 전에 해당 멤버에게 출석을 독려할 수 있도록 한다.

- N은 환경변수(`attendance.leader-noti.before-minutes`)로 설정 가능, 기본값 3분
- AdminMember에 memberId 컬럼을 추가하여 운영진-멤버 계정 연결

## 변경사항

### mashup-domain
- `AdminMember`: `memberId` (Long, nullable) 컬럼 추가
- `Position`: `isLeaderOrSubLeader()`, `toPlatform(Team)` 헬퍼 메서드 추가
- `AdminMemberRepository`: 리더 Position + memberId not null 조회 쿼리
- `AdminMemberService`: `getLeadersWithMemberId()` 메서드
- `AttendanceCodeRepository/Service`: `latenessCheckEndedAt` 범위 쿼리
- `MemberService`: 예외 없는 배치 조회 `findAllByIds()` 추가
- `AttendanceLateForLeaderVo`, `AttendanceAbsentForLeaderVo`: 리더용 푸시 VO 신규

### mashup-member
- `AttendanceFacadeService`: 스케줄러 2개 추가
  - `sendAttendanceLatePushNotiToLeaders()` — 출석 마감 N분 전, 미출석자 명단 푸시
  - `sendAttendanceAbsentPushNotiToLeaders()` — 지각 마감 N분 전, 미출석자 명단 푸시
- `@Value("${attendance.leader-noti.before-minutes:3}")` 환경변수 주입

### 푸시 메시지 예시
```
제목: 출석 현황 알림
본문: Spring에서 아직 출석하지 않은 멤버가 있어요: 홍길동, 김철수
```

### 시간 흐름 (N=3분 예시)
```
14:00  출석 시작
14:07  ★ 리더에게 미출석자 푸시 (출석 마감 3분 전)
14:10  출석 마감
14:17  ★ 리더에게 미출석자 푸시 (지각 마감 3분 전)
14:20  지각 마감
```

### 사전 조건
- `ALTER TABLE admin_member ADD COLUMN member_id BIGINT NULL;` DDL 실행 필요
- 리더 AdminMember의 memberId를 해당 Member ID로 수동 연결 필요
- (선택) `attendance.leader-noti.before-minutes` 환경변수 설정 (미설정 시 기본 3분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)