### PR TITLE
feat: 출석 현황 Discord 웹훅 알림 추가

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/config/DiscordWebhookConfig.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/config/DiscordWebhookConfig.java
@@ -1,0 +1,14 @@
+package kr.mashup.branding.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class DiscordWebhookConfig {
+
+    @Bean
+    public RestTemplate discordRestTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceDiscordVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceDiscordVo.java
@@ -1,0 +1,10 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AttendanceDiscordVo {
+    private final String content;
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/discord/DiscordWebhookService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/discord/DiscordWebhookService.java
@@ -1,0 +1,27 @@
+package kr.mashup.branding.infrastructure.discord;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordWebhookService {
+
+    private final RestTemplate discordRestTemplate;
+
+    @Value("${discord.webhook-url:}")
+    private String webhookUrl;
+
+    public void send(String content) {
+        if (!StringUtils.hasText(webhookUrl)) return;
+        Map<String, String> body = Map.of("content", content);
+        discordRestTemplate.postForEntity(webhookUrl, body, String.class);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/PushNotiEventPublisher.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/infrastructure/pushnoti/PushNotiEventPublisher.java
@@ -1,5 +1,6 @@
 package kr.mashup.branding.infrastructure.pushnoti;
 
+import kr.mashup.branding.domain.pushnoti.vo.AttendanceDiscordVo;
 import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -12,5 +13,9 @@ public class PushNotiEventPublisher {
 
     public void publishPushNotiSendEvent(PushNotiSendVo pushNotiSendEvent){
         eventPublisher.publishEvent(pushNotiSendEvent);
+    }
+
+    public void publishDiscordEvent(AttendanceDiscordVo discordEvent){
+        eventPublisher.publishEvent(discordEvent);
     }
 }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -13,6 +13,7 @@ import kr.mashup.branding.domain.member.MemberGeneration;
 import kr.mashup.branding.domain.member.Platform;
 import kr.mashup.branding.domain.adminmember.entity.AdminMember;
 import kr.mashup.branding.domain.adminmember.entity.Position;
+import kr.mashup.branding.domain.pushnoti.vo.AttendanceDiscordVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceAbsentForLeaderVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceEndingVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceLateForLeaderVo;
@@ -200,7 +201,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceLatePushNotiToLeaders() {
-        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new);
+        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new, "출석 마감");
     }
 
     /**
@@ -209,16 +210,18 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceAbsentPushNotiToLeaders() {
-        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new);
+        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new, "지각 마감");
     }
 
     private void sendLeaderPushNoti(
             final List<AttendanceCode> attendanceCodes,
-            final LeaderNotiVoFactory voFactory
+            final LeaderNotiVoFactory voFactory,
+            final String notiLabel
     ) {
         if (attendanceCodes.isEmpty()) return;
 
         final Map<Platform, List<Member>> leadersByPlatform = resolveLeadersByPlatform();
+        final Map<Platform, List<Member>> notCheckedByPlatform = new LinkedHashMap<>();
 
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
@@ -238,6 +241,8 @@ public class AttendanceFacadeService {
                 final List<Member> notCheckedMembers = new ArrayList<>(platformMembers);
                 notCheckedMembers.removeAll(checkedMembers);
 
+                notCheckedByPlatform.put(platform, notCheckedMembers);
+
                 if (notCheckedMembers.isEmpty()) continue;
 
                 final List<Member> leaderMembers = leadersByPlatform.getOrDefault(platform, Collections.emptyList());
@@ -248,6 +253,11 @@ public class AttendanceFacadeService {
                 pushNotiEventPublisher.publishPushNotiSendEvent(
                         voFactory.create(leaderMembers, platform.getName(), names));
             }
+        }
+
+        final String discordContent = buildDiscordContent(notCheckedByPlatform, notiLabel);
+        if (discordContent != null) {
+            pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(discordContent));
         }
     }
 
@@ -280,6 +290,29 @@ public class AttendanceFacadeService {
             }
         }
         return result;
+    }
+
+    private String buildDiscordContent(
+            final Map<Platform, List<Member>> notCheckedByPlatform,
+            final String notiLabel
+    ) {
+        if (notCheckedByPlatform.isEmpty()) return null;
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append("📋 **출석 현황 알림** (").append(notiLabel).append(" ")
+                .append(leaderNotiBeforeMinutes).append("분 전)\n");
+
+        for (Platform platform : Platform.values()) {
+            final List<Member> members = notCheckedByPlatform.get(platform);
+            if (members == null || members.isEmpty()) {
+                sb.append(platform.getName()).append(": ✅ 전원 출석\n");
+            } else {
+                sb.append(platform.getName()).append(" (").append(members.size())
+                        .append("명): ").append(formatNames(members)).append("\n");
+            }
+        }
+
+        return sb.toString();
     }
 
     private String formatNames(List<Member> members) {

--- a/mashup-member/src/main/java/kr/mashup/branding/ui/discord/DiscordWebhookEventListener.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/ui/discord/DiscordWebhookEventListener.java
@@ -1,0 +1,32 @@
+package kr.mashup.branding.ui.discord;
+
+import kr.mashup.branding.config.async.ThreadPoolName;
+import kr.mashup.branding.domain.pushnoti.vo.AttendanceDiscordVo;
+import kr.mashup.branding.infrastructure.discord.DiscordWebhookService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordWebhookEventListener {
+
+    private final DiscordWebhookService discordWebhookService;
+
+    @Async(value = ThreadPoolName.PUSH_NOTI_SEND_THREAD_POOL)
+    @Transactional(propagation = Propagation.NEVER)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDiscordWebhookEvent(AttendanceDiscordVo event) {
+        try {
+            discordWebhookService.send(event.getContent());
+        } catch (Exception e) {
+            log.error("[DISCORD_WEBHOOK_FAIL] failed to send: {}", e.getMessage());
+        }
+    }
+}

--- a/mashup-member/src/main/resources/member.yml
+++ b/mashup-member/src/main/resources/member.yml
@@ -7,3 +7,6 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
+discord:
+  webhook-url: ""


### PR DESCRIPTION
## PR 타입
Feature

## 개요
기존 리더 FCM 푸시(#490)와 동일 시점(마감 N분 전)에 Discord 웹훅으로 전체 플랫폼 미출석 현황을 발송한다.
기존 외부 API 호출 패턴(Event → @Async @TransactionalEventListener → Service)을 그대로 따르며,
Discord 발송 실패 시에도 FCM 푸시에 영향 없다.

## 변경사항

### mashup-domain
- `DiscordWebhookConfig`: RestTemplate Bean 생성
- `DiscordWebhookService`: Discord 웹훅 POST 발송 (URL 미설정 시 no-op)
- `AttendanceDiscordVo`: Discord 이벤트 VO (POJO)
- `PushNotiEventPublisher`: `publishDiscordEvent()` 메서드 추가

### mashup-member
- `DiscordWebhookEventListener`: @Async + @TransactionalEventListener + Propagation.NEVER (기존 PushNotiEventListener 패턴 동일)
- `AttendanceFacadeService`: 플랫폼별 미출석 현황 수집 → Discord 메시지 조립 → 이벤트 발행
- `member.yml`: `discord.webhook-url` 설정 추가

### Discord 메시지 예시
```
📋 출석 현황 알림 (출석 마감 3분 전)
Spring (2명): 홍길동, 김철수
iOS (1명): 이영희
Android: ✅ 전원 출석
Design: ✅ 전원 출석
Web (3명): 박지훈, 최민수, 정하늘
Node: ✅ 전원 출석
```

### 사전 조건
- Discord 채널에서 웹훅 URL 발급
- `discord.webhook-url`에 URL 설정 (미설정 시 Discord 발송 안 함, 기존 동작 무영향)
- DB 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)