### PR TITLE
fix: 생일 푸시 알림 generation 필터 누락 버그 수정

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/member/MemberRepositoryCustomImpl.java
@@ -157,6 +157,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
             .where(
                 memberProfile.birthDate.month().eq(monthDay.getMonthValue())
                     .and(memberProfile.birthDate.dayOfMonth().eq(monthDay.getDayOfMonth()))
+                    .and(memberGeneration.generation.eq(generation))
             )
             .fetch();
     }

--- a/mashup-domain/src/test/java/kr/mashup/branding/service/member/MemberServiceBirthdayTest.java
+++ b/mashup-domain/src/test/java/kr/mashup/branding/service/member/MemberServiceBirthdayTest.java
@@ -1,0 +1,105 @@
+package kr.mashup.branding.service.member;
+
+import kr.mashup.branding.domain.generation.Generation;
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.repository.member.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.MonthDay;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceBirthdayTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService sut;
+
+    @Test
+    @DisplayName("getAllByBirthdayRecipient는 해당 기수의 생일자만 반환한다")
+    void getAllByBirthdayRecipient_delegatesToRepository() {
+        // given
+        Generation generation = mock(Generation.class);
+        Member birthdayMember = mock(Member.class);
+
+        when(memberRepository.retrieveByBirthDate(eq(generation), any(MonthDay.class)))
+                .thenReturn(List.of(birthdayMember));
+
+        // when
+        List<Member> result = sut.getAllByBirthdayRecipient(generation);
+
+        // then
+        assertThat(result).containsExactly(birthdayMember);
+        verify(memberRepository).retrieveByBirthDate(eq(generation), any(MonthDay.class));
+    }
+
+    @Test
+    @DisplayName("getAllByBirthdaySender는 생일자가 없으면 빈 리스트를 반환한다")
+    void getAllByBirthdaySender_emptyWhenNoBirthday() {
+        // given
+        Generation generation = mock(Generation.class);
+
+        when(memberRepository.retrieveByBirthDate(eq(generation), any(MonthDay.class)))
+                .thenReturn(List.of());
+
+        // when
+        List<Member> result = sut.getAllByBirthdaySender(generation);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(memberRepository, never()).findAllActiveByGeneration(any());
+    }
+
+    @Test
+    @DisplayName("getAllByBirthdaySender는 생일자가 1명이면 발신자 목록에서 생일자를 제외한다")
+    void getAllByBirthdaySender_excludesSingleRecipient() {
+        // given
+        Generation generation = mock(Generation.class);
+        Member birthdayMember = mock(Member.class);
+        Member otherMember = mock(Member.class);
+
+        when(memberRepository.retrieveByBirthDate(eq(generation), any(MonthDay.class)))
+                .thenReturn(List.of(birthdayMember));
+        when(memberRepository.findAllActiveByGeneration(generation))
+                .thenReturn(new ArrayList<>(List.of(birthdayMember, otherMember)));
+
+        // when
+        List<Member> result = sut.getAllByBirthdaySender(generation);
+
+        // then
+        assertThat(result).containsExactly(otherMember);
+        assertThat(result).doesNotContain(birthdayMember);
+    }
+
+    @Test
+    @DisplayName("getAllByBirthdaySender는 생일자가 2명 이상이면 발신자 목록에서 제외하지 않는다")
+    void getAllByBirthdaySender_doesNotExcludeMultipleRecipients() {
+        // given
+        Generation generation = mock(Generation.class);
+        Member birthdayMember1 = mock(Member.class);
+        Member birthdayMember2 = mock(Member.class);
+        Member otherMember = mock(Member.class);
+
+        when(memberRepository.retrieveByBirthDate(eq(generation), any(MonthDay.class)))
+                .thenReturn(List.of(birthdayMember1, birthdayMember2));
+        when(memberRepository.findAllActiveByGeneration(generation))
+                .thenReturn(new ArrayList<>(List.of(birthdayMember1, birthdayMember2, otherMember)));
+
+        // when
+        List<Member> result = sut.getAllByBirthdaySender(generation);
+
+        // then
+        assertThat(result).containsExactly(birthdayMember1, birthdayMember2, otherMember);
+    }
+}


### PR DESCRIPTION
## PR 타입
Bug Fix

## 개요
`MemberRepositoryCustomImpl.retrieveByBirthDate(Generation, MonthDay)` 메서드가 `generation` 파라미터를 WHERE절에서 사용하지 않아, 모든 기수의 생일자가 조회되던 버그 수정.

Closes #496

## 변경사항

### 버그 수정
- `MemberRepositoryCustomImpl.retrieveByBirthDate()`: WHERE절에 `.and(memberGeneration.generation.eq(generation))` 조건 추가
- `cf929a2`에서 `LocalDate → MonthDay` 리팩터링 시 누락된 조건 복원
- 동일 프로젝트 `MemberProfileRepositoryCustomImpl.retrieveByBirthDateBetween()`의 WHERE절 패턴과 일치시킴

### 단위 테스트 추가
- `MemberServiceBirthdayTest`: 생일 푸시 관련 4개 테스트 케이스
  - `getAllByBirthdayRecipient`는 generation을 전달하여 repository 호출
  - `getAllByBirthdaySender`는 생일자 없으면 빈 리스트 반환
  - `getAllByBirthdaySender`는 생일자 1명이면 발신자 목록에서 제외
  - `getAllByBirthdaySender`는 생일자 2명 이상이면 발신자 목록에서 제외하지 않음