### PR TITLE
feat: Discord 출석 알림 개선 - 이모지, 통계, 일정명, 최종결과

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceAbsentForLeaderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceAbsentForLeaderVo.java
@@ -9,7 +9,7 @@ import kr.mashup.branding.domain.pushnoti.LinkType;
 
 public class AttendanceAbsentForLeaderVo extends PushNotiSendVo {
     private static final PushType pushType = PushType.ATTENDANCE;
-    private static final String title = "출석 현황 알림";
+    private static final String title = "⚠️ 출석 현황 알림";
     private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
 
     public AttendanceAbsentForLeaderVo(List<Member> leaders, String platformName, String absentNames) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceLateForLeaderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/AttendanceLateForLeaderVo.java
@@ -9,7 +9,7 @@ import kr.mashup.branding.domain.pushnoti.LinkType;
 
 public class AttendanceLateForLeaderVo extends PushNotiSendVo {
     private static final PushType pushType = PushType.ATTENDANCE;
-    private static final String title = "출석 현황 알림";
+    private static final String title = "⏰ 출석 현황 알림";
     private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
 
     public AttendanceLateForLeaderVo(List<Member> leaders, String platformName, String lateNames) {

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -262,7 +262,8 @@ public class AttendanceFacadeService {
 
             final int totalAbsent = totalMembers - totalAttendance - totalLate;
             final String content = buildDiscordContent(
-                    absentByPlatform, lateByPlatform, "📊 최종 결과", schedule.getName(), null,
+                    absentByPlatform, lateByPlatform, "📊 최종 결과", schedule.getName(),
+                    event.getEventName(), null,
                     totalAttendance, totalLate, totalAbsent, totalMembers);
             if (content != null) {
                 pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(content));
@@ -283,6 +284,7 @@ public class AttendanceFacadeService {
         int totalLate = 0;
         int totalMembers = 0;
         String scheduleName = "";
+        String eventName = null;
         LocalDateTime deadlineAt = null;
 
         for (AttendanceCode attendanceCode : attendanceCodes) {
@@ -290,6 +292,7 @@ public class AttendanceFacadeService {
             final Schedule schedule = event.getSchedule();
             final Generation generation = schedule.getGeneration();
             scheduleName = schedule.getName();
+            eventName = event.getEventName();
             deadlineAt = attendanceCode.getAttendanceCheckEndedAt();
 
             final List<Attendance> attendances = attendanceService.getByEvent(event);
@@ -330,7 +333,7 @@ public class AttendanceFacadeService {
 
         final int totalAbsent = totalMembers - totalAttendance - totalLate;
         final String discordContent = buildDiscordContent(
-                notCheckedByPlatform, null, notiLabel, scheduleName, deadlineAt,
+                notCheckedByPlatform, Collections.emptyMap(), notiLabel, scheduleName, eventName, deadlineAt,
                 totalAttendance, totalLate, totalAbsent, totalMembers);
         if (discordContent != null) {
             pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(discordContent));
@@ -373,6 +376,7 @@ public class AttendanceFacadeService {
             final Map<Platform, List<Member>> lateByPlatform,
             final String notiLabel,
             final String scheduleName,
+            final String eventName,
             final LocalDateTime deadlineAt,
             final int totalAttendance,
             final int totalLate,
@@ -383,7 +387,11 @@ public class AttendanceFacadeService {
 
         final StringBuilder sb = new StringBuilder();
         sb.append("---\n");
-        sb.append("**").append(scheduleName).append("** | ").append(notiLabel);
+        sb.append("**").append(scheduleName);
+        if (eventName != null && !eventName.isEmpty()) {
+            sb.append(" - ").append(eventName);
+        }
+        sb.append("** | ").append(notiLabel);
         if (deadlineAt != null) {
             sb.append(" ").append(leaderNotiBeforeMinutes).append("분 전")
                     .append(" (마감 ").append(String.format("%02d:%02d", deadlineAt.getHour(), deadlineAt.getMinute())).append(")");
@@ -395,32 +403,22 @@ public class AttendanceFacadeService {
 
         for (Platform platform : Platform.values()) {
             final List<Member> absentMembers = notCheckedByPlatform.get(platform);
+            final List<Member> lateMembers = lateByPlatform.getOrDefault(platform, Collections.emptyList());
             final boolean hasAbsent = absentMembers != null && !absentMembers.isEmpty();
+            final boolean hasLate = !lateMembers.isEmpty();
 
-            if (lateByPlatform != null) {
-                final List<Member> lateMembers = lateByPlatform.get(platform);
-                final boolean hasLate = lateMembers != null && !lateMembers.isEmpty();
-
-                if (!hasAbsent && !hasLate) {
-                    allClear.add(platform.getName());
-                } else {
-                    final StringBuilder line = new StringBuilder();
-                    line.append(platform.getName());
-                    if (hasLate) {
-                        line.append(" | 지각 **").append(formatNames(lateMembers)).append("**");
-                    }
-                    if (hasAbsent) {
-                        line.append(" | 결석 **").append(formatNames(absentMembers)).append("**");
-                    }
-                    issues.add(line.toString());
-                }
+            if (!hasAbsent && !hasLate) {
+                allClear.add(platform.getName());
             } else {
-                if (!hasAbsent) {
-                    allClear.add(platform.getName());
-                } else {
-                    issues.add(platform.getName() + " (**" + absentMembers.size()
-                            + "명**): **" + formatNames(absentMembers) + "**");
+                final StringBuilder line = new StringBuilder();
+                line.append(platform.getName());
+                if (hasLate) {
+                    line.append(" | 지각 **").append(formatNames(lateMembers)).append("**");
                 }
+                if (hasAbsent) {
+                    line.append(" | 결석 **").append(formatNames(absentMembers)).append("**");
+                }
+                issues.add(line.toString());
             }
         }
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -233,24 +233,37 @@ public class AttendanceFacadeService {
             int totalLate = (int) attendances.stream()
                     .filter(a -> a.getStatus() == AttendanceStatus.LATE).count();
 
+            final Map<Member, AttendanceStatus> memberStatusMap = new HashMap<>();
+            attendances.forEach(a -> memberStatusMap.put(a.getMember(), a.getStatus()));
+
             int totalMembers = 0;
             final Map<Platform, List<Member>> absentByPlatform = new LinkedHashMap<>();
-            final List<Member> checkedMembers = attendances.stream()
-                    .map(Attendance::getMember).collect(Collectors.toList());
+            final Map<Platform, List<Member>> lateByPlatform = new LinkedHashMap<>();
 
             for (Platform platform : Platform.values()) {
                 if (!schedule.checkAvailabilityByPlatform(platform)) continue;
                 final List<Member> platformMembers =
                         memberService.getAllByPlatformAndGeneration(platform, generation);
                 totalMembers += platformMembers.size();
-                final List<Member> absent = new ArrayList<>(platformMembers);
-                absent.removeAll(checkedMembers);
+
+                final List<Member> absent = new ArrayList<>();
+                final List<Member> late = new ArrayList<>();
+                for (Member m : platformMembers) {
+                    final AttendanceStatus status = memberStatusMap.get(m);
+                    if (status == null) {
+                        absent.add(m);
+                    } else if (status == AttendanceStatus.LATE) {
+                        late.add(m);
+                    }
+                }
                 absentByPlatform.put(platform, absent);
+                lateByPlatform.put(platform, late);
             }
 
             final int totalAbsent = totalMembers - totalAttendance - totalLate;
-            final String content = buildDiscordContent(absentByPlatform, "📊 최종 결과",
-                    totalAttendance, totalLate, totalAbsent);
+            final String content = buildDiscordContent(
+                    absentByPlatform, lateByPlatform, "📊 최종 결과", schedule.getName(), null,
+                    totalAttendance, totalLate, totalAbsent, totalMembers);
             if (content != null) {
                 pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(content));
             }
@@ -269,11 +282,15 @@ public class AttendanceFacadeService {
         int totalAttendance = 0;
         int totalLate = 0;
         int totalMembers = 0;
+        String scheduleName = "";
+        LocalDateTime deadlineAt = null;
 
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
             final Generation generation = schedule.getGeneration();
+            scheduleName = schedule.getName();
+            deadlineAt = attendanceCode.getAttendanceCheckEndedAt();
 
             final List<Attendance> attendances = attendanceService.getByEvent(event);
             final List<Member> checkedMembers = attendances.stream()
@@ -313,7 +330,8 @@ public class AttendanceFacadeService {
 
         final int totalAbsent = totalMembers - totalAttendance - totalLate;
         final String discordContent = buildDiscordContent(
-                notCheckedByPlatform, notiLabel, totalAttendance, totalLate, totalAbsent);
+                notCheckedByPlatform, null, notiLabel, scheduleName, deadlineAt,
+                totalAttendance, totalLate, totalAbsent, totalMembers);
         if (discordContent != null) {
             pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(discordContent));
         }
@@ -352,29 +370,69 @@ public class AttendanceFacadeService {
 
     private String buildDiscordContent(
             final Map<Platform, List<Member>> notCheckedByPlatform,
+            final Map<Platform, List<Member>> lateByPlatform,
             final String notiLabel,
+            final String scheduleName,
+            final LocalDateTime deadlineAt,
             final int totalAttendance,
             final int totalLate,
-            final int totalAbsent
+            final int totalAbsent,
+            final int totalMembers
     ) {
         if (notCheckedByPlatform.isEmpty()) return null;
 
         final StringBuilder sb = new StringBuilder();
         sb.append("---\n");
-        sb.append("**출석 현황 알림** (").append(notiLabel).append(" ")
-                .append(leaderNotiBeforeMinutes).append("분 전)\n\n");
+        sb.append("**").append(scheduleName).append("** | ").append(notiLabel);
+        if (deadlineAt != null) {
+            sb.append(" ").append(leaderNotiBeforeMinutes).append("분 전")
+                    .append(" (마감 ").append(String.format("%02d:%02d", deadlineAt.getHour(), deadlineAt.getMinute())).append(")");
+        }
+        sb.append("\n\n");
+
+        final List<String> allClear = new ArrayList<>();
+        final List<String> issues = new ArrayList<>();
 
         for (Platform platform : Platform.values()) {
-            final List<Member> members = notCheckedByPlatform.get(platform);
-            if (members == null || members.isEmpty()) {
-                sb.append(platform.getName()).append(": ✅ 전원 출석\n");
+            final List<Member> absentMembers = notCheckedByPlatform.get(platform);
+            final boolean hasAbsent = absentMembers != null && !absentMembers.isEmpty();
+
+            if (lateByPlatform != null) {
+                final List<Member> lateMembers = lateByPlatform.get(platform);
+                final boolean hasLate = lateMembers != null && !lateMembers.isEmpty();
+
+                if (!hasAbsent && !hasLate) {
+                    allClear.add(platform.getName());
+                } else {
+                    final StringBuilder line = new StringBuilder();
+                    line.append(platform.getName());
+                    if (hasLate) {
+                        line.append(" | 지각 **").append(formatNames(lateMembers)).append("**");
+                    }
+                    if (hasAbsent) {
+                        line.append(" | 결석 **").append(formatNames(absentMembers)).append("**");
+                    }
+                    issues.add(line.toString());
+                }
             } else {
-                sb.append(platform.getName()).append(" (**").append(members.size())
-                        .append("명**): **").append(formatNames(members)).append("**\n");
+                if (!hasAbsent) {
+                    allClear.add(platform.getName());
+                } else {
+                    issues.add(platform.getName() + " (**" + absentMembers.size()
+                            + "명**): **" + formatNames(absentMembers) + "**");
+                }
             }
         }
 
-        sb.append("\n> 출석 **").append(totalAttendance).append("명**")
+        for (String issue : issues) {
+            sb.append(issue).append("\n");
+        }
+        if (!allClear.isEmpty()) {
+            sb.append(String.join(", ", allClear)).append(": ✅ 전원 출석\n");
+        }
+
+        final int attendanceRate = totalMembers > 0 ? (totalAttendance * 100 / totalMembers) : 0;
+        sb.append("\n> 출석 **").append(totalAttendance).append("명** (").append(attendanceRate).append("%)")
                 .append(" / 지각 **").append(totalLate).append("명**")
                 .append(" / 결석 **").append(totalAbsent).append("명**");
 

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -201,7 +201,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceLatePushNotiToLeaders() {
-        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new, "출석 마감");
+        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new, "⏰ 출석 마감");
     }
 
     /**
@@ -210,7 +210,51 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceAbsentPushNotiToLeaders() {
-        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new, "지각 마감");
+        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new, "⚠️ 지각 마감");
+    }
+
+    /**
+     * 지각 마감 시점: Discord에 최종 출석 결과 발송
+     */
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional(readOnly = true)
+    public void sendAttendanceFinalResultToDiscord() {
+        final List<AttendanceCode> attendanceCodes = findAllLatenessEndsWithin(0L);
+        if (attendanceCodes.isEmpty()) return;
+
+        for (AttendanceCode attendanceCode : attendanceCodes) {
+            final Event event = attendanceCode.getEvent();
+            final Schedule schedule = event.getSchedule();
+            final Generation generation = schedule.getGeneration();
+
+            final List<Attendance> attendances = attendanceService.getByEvent(event);
+            int totalAttendance = (int) attendances.stream()
+                    .filter(a -> a.getStatus() == AttendanceStatus.ATTENDANCE).count();
+            int totalLate = (int) attendances.stream()
+                    .filter(a -> a.getStatus() == AttendanceStatus.LATE).count();
+
+            int totalMembers = 0;
+            final Map<Platform, List<Member>> absentByPlatform = new LinkedHashMap<>();
+            final List<Member> checkedMembers = attendances.stream()
+                    .map(Attendance::getMember).collect(Collectors.toList());
+
+            for (Platform platform : Platform.values()) {
+                if (!schedule.checkAvailabilityByPlatform(platform)) continue;
+                final List<Member> platformMembers =
+                        memberService.getAllByPlatformAndGeneration(platform, generation);
+                totalMembers += platformMembers.size();
+                final List<Member> absent = new ArrayList<>(platformMembers);
+                absent.removeAll(checkedMembers);
+                absentByPlatform.put(platform, absent);
+            }
+
+            final int totalAbsent = totalMembers - totalAttendance - totalLate;
+            final String content = buildDiscordContent(absentByPlatform, "📊 최종 결과",
+                    totalAttendance, totalLate, totalAbsent);
+            if (content != null) {
+                pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(content));
+            }
+        }
     }
 
     private void sendLeaderPushNoti(
@@ -317,7 +361,7 @@ public class AttendanceFacadeService {
 
         final StringBuilder sb = new StringBuilder();
         sb.append("---\n");
-        sb.append("📋 **출석 현황 알림** (").append(notiLabel).append(" ")
+        sb.append("**출석 현황 알림** (").append(notiLabel).append(" ")
                 .append(leaderNotiBeforeMinutes).append("분 전)\n\n");
 
         for (Platform platform : Platform.values()) {

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -222,21 +222,33 @@ public class AttendanceFacadeService {
 
         final Map<Platform, List<Member>> leadersByPlatform = resolveLeadersByPlatform();
         final Map<Platform, List<Member>> notCheckedByPlatform = new LinkedHashMap<>();
+        int totalAttendance = 0;
+        int totalLate = 0;
+        int totalMembers = 0;
 
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
             final Generation generation = schedule.getGeneration();
 
-            final List<Member> checkedMembers = attendanceService.getByEvent(event).stream()
+            final List<Attendance> attendances = attendanceService.getByEvent(event);
+            final List<Member> checkedMembers = attendances.stream()
                     .map(Attendance::getMember)
                     .collect(Collectors.toList());
+
+            totalAttendance += attendances.stream()
+                    .filter(a -> a.getStatus() == AttendanceStatus.ATTENDANCE)
+                    .count();
+            totalLate += attendances.stream()
+                    .filter(a -> a.getStatus() == AttendanceStatus.LATE)
+                    .count();
 
             for (Platform platform : Platform.values()) {
                 if (!schedule.checkAvailabilityByPlatform(platform)) continue;
 
                 final List<Member> platformMembers =
                         memberService.getAllByPlatformAndGeneration(platform, generation);
+                totalMembers += platformMembers.size();
 
                 final List<Member> notCheckedMembers = new ArrayList<>(platformMembers);
                 notCheckedMembers.removeAll(checkedMembers);
@@ -255,7 +267,9 @@ public class AttendanceFacadeService {
             }
         }
 
-        final String discordContent = buildDiscordContent(notCheckedByPlatform, notiLabel);
+        final int totalAbsent = totalMembers - totalAttendance - totalLate;
+        final String discordContent = buildDiscordContent(
+                notCheckedByPlatform, notiLabel, totalAttendance, totalLate, totalAbsent);
         if (discordContent != null) {
             pushNotiEventPublisher.publishDiscordEvent(new AttendanceDiscordVo(discordContent));
         }
@@ -294,23 +308,31 @@ public class AttendanceFacadeService {
 
     private String buildDiscordContent(
             final Map<Platform, List<Member>> notCheckedByPlatform,
-            final String notiLabel
+            final String notiLabel,
+            final int totalAttendance,
+            final int totalLate,
+            final int totalAbsent
     ) {
         if (notCheckedByPlatform.isEmpty()) return null;
 
         final StringBuilder sb = new StringBuilder();
+        sb.append("---\n");
         sb.append("📋 **출석 현황 알림** (").append(notiLabel).append(" ")
-                .append(leaderNotiBeforeMinutes).append("분 전)\n");
+                .append(leaderNotiBeforeMinutes).append("분 전)\n\n");
 
         for (Platform platform : Platform.values()) {
             final List<Member> members = notCheckedByPlatform.get(platform);
             if (members == null || members.isEmpty()) {
                 sb.append(platform.getName()).append(": ✅ 전원 출석\n");
             } else {
-                sb.append(platform.getName()).append(" (").append(members.size())
-                        .append("명): ").append(formatNames(members)).append("\n");
+                sb.append(platform.getName()).append(" (**").append(members.size())
+                        .append("명**): **").append(formatNames(members)).append("**\n");
             }
         }
+
+        sb.append("\n> 출석 **").append(totalAttendance).append("명**")
+                .append(" / 지각 **").append(totalLate).append("명**")
+                .append(" / 결석 **").append(totalAbsent).append("명**");
 
         return sb.toString();
     }


### PR DESCRIPTION
## PR 타입
Feature Enhancement

## 개요
PR #491 머지 이후 Discord 출석 알림 메시지 개선.
- 알림 단계별 이모지 구분 (⏰/⚠️/📊)
- 지각 마감 후 최종 출석 결과 Discord 발송 추가
- 일정명, 이벤트명(1부/2부), 마감 시간 표시
- 미출석자 볼드, 전원 출석 플랫폼 압축
- 출석률 퍼센트 + 출석/지각/결석 통계
- 최종 결과에서 지각자/결석자 명단 구분

## 변경사항

### mashup-domain
- `AttendanceLateForLeaderVo`: FCM 타이틀에 ⏰ 이모지 추가
- `AttendanceAbsentForLeaderVo`: FCM 타이틀에 ⚠️ 이모지 추가

### mashup-member
- `AttendanceFacadeService`
  - `sendAttendanceFinalResultToDiscord()`: 지각 마감 시점 최종 결과 Discord 전송 (지각자/결석자 구분)
  - `buildDiscordContent()`: 일정명, 이벤트명, 마감시간, 출석률%, 통계 포함
  - 전원 출석 플랫폼은 하단 한 줄로 압축

### 환경변수
- `member-develop.yml`: Discord 웹훅 URL 추가 (ENC)
- `member-production.yml`: Discord 웹훅 URL 추가 (ENC)

### Discord 메시지 예시
```
---
**16기 정기세미나 - 1부** | ⏰ 출석 마감 3분 전 (마감 14:10)

Android (5명): **홍길동, 김철수, 이영희, 박지훈, 최민수**
Spring, iOS, Product Design, Web, Node: ✅ 전원 출석

> 출석 **12명** (70%) / 지각 **0명** / 결석 **5명**
```
```
---
**16기 정기세미나 - 1부** | 📊 최종 결과

Android | 지각 **홍길동, 김철수** | 결석 **이영희, 박지훈, 최민수**
Spring, iOS, Product Design, Web, Node: ✅ 전원 출석

> 출석 **12명** (70%) / 지각 **2명** / 결석 **3명**
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)