### PR TITLE
feat: leaderNotiBeforeMinutes를 Storage 테이블로 이관 (#493)

### DIFF
--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -29,12 +29,12 @@ import kr.mashup.branding.service.attendance.AttendanceCodeService;
 import kr.mashup.branding.service.attendance.AttendanceService;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.schedule.ScheduleService;
+import kr.mashup.branding.service.storage.StorageService;
 import kr.mashup.branding.ui.attendance.request.AttendanceCheckRequest;
 import kr.mashup.branding.ui.attendance.response.*;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,8 +55,8 @@ public class AttendanceFacadeService {
     private final static long ATTENDANCE_END_AFTER_MINUTES = 3;
     private final static double ATTENDANCE_DISTANCE = 1000;
 
-    @Value("${attendance.leader-noti.before-minutes:3}")
-    private long leaderNotiBeforeMinutes;
+    private static final String LEADER_NOTI_BEFORE_MINUTES_KEY = "leader-noti-before-minutes";
+    private static final long DEFAULT_LEADER_NOTI_BEFORE_MINUTES = 3;
 
     private final AttendanceService attendanceService;
     private final MemberService memberService;
@@ -64,6 +64,7 @@ public class AttendanceFacadeService {
     private final AttendanceCodeService attendanceCodeService;
     private final PushNotiEventPublisher pushNotiEventPublisher;
     private final AdminMemberService adminMemberService;
+    private final StorageService storageService;
 
     /**
      * 출석 체크
@@ -201,7 +202,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceLatePushNotiToLeaders() {
-        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new, "⏰ 출석 마감");
+        sendLeaderPushNoti(findAllEndsWithin(getLeaderNotiBeforeMinutes()), AttendanceLateForLeaderVo::new, "⏰ 출석 마감");
     }
 
     /**
@@ -210,7 +211,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceAbsentPushNotiToLeaders() {
-        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new, "⚠️ 지각 마감");
+        sendLeaderPushNoti(findAllLatenessEndsWithin(getLeaderNotiBeforeMinutes()), AttendanceAbsentForLeaderVo::new, "⚠️ 지각 마감");
     }
 
     /**
@@ -393,7 +394,7 @@ public class AttendanceFacadeService {
         }
         sb.append("** | ").append(notiLabel);
         if (deadlineAt != null) {
-            sb.append(" ").append(leaderNotiBeforeMinutes).append("분 전")
+            sb.append(" ").append(getLeaderNotiBeforeMinutes()).append("분 전")
                     .append(" (마감 ").append(String.format("%02d:%02d", deadlineAt.getHour(), deadlineAt.getMinute())).append(")");
         }
         sb.append("\n\n");
@@ -445,6 +446,15 @@ public class AttendanceFacadeService {
             return String.join(", ", nameList.subList(0, 20)) + " 외 " + (nameList.size() - 20) + "명";
         }
         return String.join(", ", nameList);
+    }
+
+    private long getLeaderNotiBeforeMinutes() {
+        try {
+            final Map<String, Object> valueMap = storageService.findByKey(LEADER_NOTI_BEFORE_MINUTES_KEY).getValueMap();
+            return ((Number) valueMap.get("value")).longValue();
+        } catch (Exception e) {
+            return DEFAULT_LEADER_NOTI_BEFORE_MINUTES;
+        }
     }
 
     private List<AttendanceCode> findAllLatenessEndsWithin(Long afterMinutes) {


### PR DESCRIPTION
## PR 타입
Enhancement

## 개요
`leaderNotiBeforeMinutes`를 `@Value` 환경변수 대신 Storage(Key-Value) 테이블에서 실시간 조회하도록 변경.
Admin API(`POST /api/v1/storage`)로 재배포 없이 즉시 변경 가능.

Closes #493

## 변경사항
- `AttendanceFacadeService`: `@Value` 제거, `StorageService.findByKey()` 사용
- Storage 키: `leader-noti-before-minutes`, 값: `{"value": 3}`
- 키가 없거나 조회 실패 시 기본값 3분 fallback

## 사용 방법
```
POST /api/v1/storage
{
  "keyString": "leader-noti-before-minutes",
  "valueMap": {"value": 5}
}
```
→ 즉시 5분 전 알림으로 변경됨

## 사전 조건
- 별도 DDL 불필요 (기존 Storage 테이블 활용)
- 초기값 미등록 시 기본값 3분 적용 (에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)