### PR TITLE
chore: dev Discord 웹훅을 전용 채널로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 /mashup-domain/src/main/generated/
+
+### Claude Code ###
+CLAUDE.local.md
+.serena/

--- a/mashup-member/src/main/resources/member-develop.yml
+++ b/mashup-member/src/main/resources/member-develop.yml
@@ -9,4 +9,4 @@ aws:
       expires-in: 120 # 2 minutes
 
 discord:
-  webhook-url: ENC(znLjYrU9jbwWYN5wtTFyxFPW2Zg8zO6ok4mJOr31ed65E6iIhrdqoubwEEkmPoRHy/4hDDXnK9J5vs+01DgBMga6mJtluvLDi5ler+5IQfWmfX2ywOgPTCSV0IYAR0uRG9nw9b5y+PDVP1/zN48XgOXkSU8KylC08SzATx+k86B8ae1RlzmB70uuwwvoXt59ECjpQBAXCPQk/ZtoXwX08w==)
+  webhook-url: ENC(e9xFFVS1pWf1D6oO5JhUJU73RdfwDyH2wMFELpZhRS0EvYAs3DAc1dyktnwZzZ+vodi1LPstejIyrOPYmHK05q2fulq3pBYKJEwubtdOLRpqchVQzKn/gtNMBAI8HD7ZTiJO0RQjlo7as+PuBctypaoenbUZtefAoI6e45Iv68RPTE/bhnzHKWKX271rkqLBYbxIy5EpO91Eme+/lSRPIA==)


### PR DESCRIPTION
## PR 타입
Chore

## 개요
dev/prod가 동일한 Discord 채널을 사용해 테스트 알림과 운영 알림이 섞이던 문제 해결.
dev 전용 채널의 웹훅 URL을 Jasypt 암호화하여 적용.

Closes #505

## 변경사항
- `member-develop.yml`: `discord.webhook-url`을 dev 전용 채널 URL로 교체 (ENC)
- `.gitignore`: `CLAUDE.local.md`, `.serena/` 제외 추가
- prod는 영향 없음

## 테스트
- [ ] dev 배포 후 출석 알림이 새 dev 채널로 수신되는지 확인
- [ ] prod 채널에 dev 알림이 더 이상 오지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)