### PR TITLE
fix: Storage 조회 시 트랜잭션 rollback 문제 수정

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/service/storage/StorageService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/storage/StorageService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -29,6 +30,11 @@ public class StorageService {
     @Transactional(readOnly = true)
     public Storage findByKey(String keyString) {
         return storageRepository.findByKeyString(keyString).orElseThrow(StorageNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Storage> findByKeyOptional(String keyString) {
+        return storageRepository.findByKeyString(keyString);
     }
 
     @Transactional(readOnly = true)

--- a/mashup-domain/src/test/java/kr/mashup/branding/service/storage/StorageServiceTest.java
+++ b/mashup-domain/src/test/java/kr/mashup/branding/service/storage/StorageServiceTest.java
@@ -1,0 +1,67 @@
+package kr.mashup.branding.service.storage;
+
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.domain.storage.StorageNotFoundException;
+import kr.mashup.branding.repository.storage.StorageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StorageServiceTest {
+
+    @Mock
+    private StorageRepository storageRepository;
+
+    @InjectMocks
+    private StorageService sut;
+
+    @Test
+    @DisplayName("findByKeyOptional은 키가 존재하면 Storage를 반환한다")
+    void findByKeyOptional_returnsStorage() {
+        // given
+        Storage storage = Storage.of("test-key", Map.of("value", 5));
+        when(storageRepository.findByKeyString("test-key")).thenReturn(Optional.of(storage));
+
+        // when
+        Optional<Storage> result = sut.findByKeyOptional("test-key");
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getValueMap().get("value")).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("findByKeyOptional은 키가 없으면 빈 Optional을 반환한다 (예외 없음)")
+    void findByKeyOptional_returnsEmptyWhenNotFound() {
+        // given
+        when(storageRepository.findByKeyString("missing-key")).thenReturn(Optional.empty());
+
+        // when
+        Optional<Storage> result = sut.findByKeyOptional("missing-key");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByKey는 키가 없으면 StorageNotFoundException을 던진다")
+    void findByKey_throwsWhenNotFound() {
+        // given
+        when(storageRepository.findByKeyString("missing-key")).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sut.findByKey("missing-key"))
+                .isInstanceOf(StorageNotFoundException.class);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -449,12 +449,9 @@ public class AttendanceFacadeService {
     }
 
     private long getLeaderNotiBeforeMinutes() {
-        try {
-            final Map<String, Object> valueMap = storageService.findByKey(LEADER_NOTI_BEFORE_MINUTES_KEY).getValueMap();
-            return ((Number) valueMap.get("value")).longValue();
-        } catch (Exception e) {
-            return DEFAULT_LEADER_NOTI_BEFORE_MINUTES;
-        }
+        return storageService.findByKeyOptional(LEADER_NOTI_BEFORE_MINUTES_KEY)
+                .map(storage -> ((Number) storage.getValueMap().get("value")).longValue())
+                .orElse(DEFAULT_LEADER_NOTI_BEFORE_MINUTES);
     }
 
     private List<AttendanceCode> findAllLatenessEndsWithin(Long afterMinutes) {

--- a/mashup-member/src/test/java/kr/mashup/branding/facade/attendance/AttendanceFacadeServiceLeaderNotiTest.java
+++ b/mashup-member/src/test/java/kr/mashup/branding/facade/attendance/AttendanceFacadeServiceLeaderNotiTest.java
@@ -1,0 +1,97 @@
+package kr.mashup.branding.facade.attendance;
+
+import kr.mashup.branding.domain.attendance.AttendanceCode;
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
+import kr.mashup.branding.service.adminmember.AdminMemberService;
+import kr.mashup.branding.service.attendance.AttendanceCodeService;
+import kr.mashup.branding.service.attendance.AttendanceService;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.service.schedule.ScheduleService;
+import kr.mashup.branding.service.storage.StorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceFacadeServiceLeaderNotiTest {
+
+    @Mock
+    private AttendanceService attendanceService;
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private ScheduleService scheduleService;
+    @Mock
+    private AttendanceCodeService attendanceCodeService;
+    @Mock
+    private PushNotiEventPublisher pushNotiEventPublisher;
+    @Mock
+    private AdminMemberService adminMemberService;
+    @Mock
+    private StorageService storageService;
+
+    @InjectMocks
+    private AttendanceFacadeService sut;
+
+    @Test
+    @DisplayName("Storage에 키가 없어도 스케줄러가 예외 없이 동작한다 (기본값 3분 사용)")
+    void sendAttendanceLatePushNoti_worksWithoutStorageKey() {
+        // given
+        when(storageService.findByKeyOptional("leader-noti-before-minutes"))
+                .thenReturn(Optional.empty());
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when - 예외 없이 정상 실행되어야 함
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(storageService).findByKeyOptional("leader-noti-before-minutes");
+        verify(attendanceCodeService).findAllByEndedAtLeftOpenBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Storage에 키가 있으면 해당 값을 사용한다")
+    void sendAttendanceLatePushNoti_usesStorageValue() {
+        // given
+        Storage storage = Storage.of("leader-noti-before-minutes", Map.of("value", 5));
+        when(storageService.findByKeyOptional("leader-noti-before-minutes"))
+                .thenReturn(Optional.of(storage));
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(storageService).findByKeyOptional("leader-noti-before-minutes");
+    }
+
+    @Test
+    @DisplayName("AttendanceCode가 없으면 푸시를 발송하지 않는다")
+    void sendAttendanceLatePushNoti_noPushWhenNoAttendanceCode() {
+        // given
+        when(storageService.findByKeyOptional(any())).thenReturn(Optional.empty());
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(pushNotiEventPublisher, never()).publishPushNotiSendEvent(any());
+        verify(pushNotiEventPublisher, never()).publishDiscordEvent(any());
+    }
+}


### PR DESCRIPTION
## PR 타입
Bug Fix

## 개요
`StorageService.findByKey()`가 키 미존재 시 `StorageNotFoundException`을 던져서,
호출하는 `@Transactional(readOnly = true)` 메서드의 트랜잭션이 rollback-only로 마킹됨.
try-catch로 잡아도 트랜잭션 커밋 시점에 `UnexpectedRollbackException` 발생 → 리더 알림/Discord 웹훅 모두 실패.

## 원인
```
sendAttendanceLatePushNotiToLeaders() [@Transactional(readOnly)]
  → getLeaderNotiBeforeMinutes()
    → storageService.findByKey() [@Transactional(readOnly)]
      → StorageNotFoundException 발생 → 내부 트랜잭션 rollback-only 마킹
    → catch로 잡아도 외부 트랜잭션이 이미 오염됨
  → 커밋 시 UnexpectedRollbackException
```

## 수정
- `StorageService`에 예외를 던지지 않는 `findByKeyOptional()` 메서드 추가
- `getLeaderNotiBeforeMinutes()`에서 `Optional.map().orElse()` 패턴으로 변경
- 키 미존재 시 기본값 3분 반환, 트랜잭션 오염 없음

## 변경사항
- `StorageService.java`: `findByKeyOptional(String)` 메서드 추가
- `AttendanceFacadeService.java`: `getLeaderNotiBeforeMinutes()` Optional 패턴으로 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)