### PR TITLE
feat: 리더 출석 알림을 공식 세미나(scheduleType=ALL)에만 동작하도록 제한

### DIFF
--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -23,6 +23,7 @@ import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
 import kr.mashup.branding.service.adminmember.AdminMemberService;
 import kr.mashup.branding.service.attendance.AttendanceCodeService;
@@ -226,6 +227,9 @@ public class AttendanceFacadeService {
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
+
+            if (schedule.getScheduleType() != ScheduleType.ALL) continue;
+
             final Generation generation = schedule.getGeneration();
 
             final List<Attendance> attendances = attendanceService.getByEvent(event);
@@ -291,6 +295,9 @@ public class AttendanceFacadeService {
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
+
+            if (schedule.getScheduleType() != ScheduleType.ALL) continue;
+
             final Generation generation = schedule.getGeneration();
             scheduleName = schedule.getName();
             eventName = event.getEventName();


### PR DESCRIPTION
## PR 타입
Enhancement

## 개요
리더 출석 알림(Discord + FCM)이 모든 Schedule에서 발동되던 것을
공식 세미나(`scheduleType=ALL`)에서만 동작하도록 제한.

Closes #502

## 변경사항
- `sendLeaderPushNoti()`: `schedule.getScheduleType() != ScheduleType.ALL`이면 skip
- `sendAttendanceFinalResultToDiscord()`: 동일 조건 추가
- 기존 멤버 대상 알림(Starting, Started, Ending)은 영향 없음

## 영향 범위
- 플랫폼별 세미나 (ANDROID, SPRING 등) → 리더 알림 발동 안 됨
- 버디미션 등 기타 일정 → 리더 알림 발동 안 됨
- 공식 세미나 (ALL) → 기존대로 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)