### PR TITLE
feat: 오프라인 공식 세미나 당일 리더에게 명찰 준비 푸시 알림

### DIFF
--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarBadgeReminderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarBadgeReminderVo.java
@@ -1,0 +1,19 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import java.util.List;
+import java.util.Map;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+public class SeminarBadgeReminderVo extends PushNotiSendVo {
+    private static final PushType pushType = PushType.SEMINAR;
+    private static final String title = "📌 세미나 준비 알림";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
+
+    public SeminarBadgeReminderVo(List<Member> leaders, String scheduleName) {
+        super(leaders, pushType, title,
+              "오늘 " + scheduleName + " 오프라인 세미나가 있어요. 명찰을 챙겨주세요!", dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -159,7 +159,7 @@ public class Schedule extends BaseEntity {
     }
 
     public Boolean isOnline() {
-        return this.location == null || this.location.getLatitude() == null || this.location.getLongitude() == null;
+        return this.location == null || "ZOOM".equals(this.location.getDetailAddress());
     }
 
     public Boolean checkAvailabilityByPlatform(Platform platform) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -17,6 +17,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
     Optional<Schedule> findByIdAndStatus(Long id, ScheduleStatus status);
 
     List<Schedule> findByGenerationAndStatusOrderByStartedAtAsc(Generation generation, ScheduleStatus status);
+
+    List<Schedule> findAllByStartedAtBetweenAndStatusAndScheduleType(
+            LocalDateTime from, LocalDateTime to, ScheduleStatus status, ScheduleType scheduleType);
 }
 /**
  * Schedule 연관관계

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -18,7 +18,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
 
     List<Schedule> findByGenerationAndStatusOrderByStartedAtAsc(Generation generation, ScheduleStatus status);
 
-    List<Schedule> findAllByStartedAtBetweenAndStatusAndScheduleType(
+    List<Schedule> findAllByStartedAtGreaterThanEqualAndStartedAtLessThanAndStatusAndScheduleType(
             LocalDateTime from, LocalDateTime to, ScheduleStatus status, ScheduleType scheduleType);
 }
 /**

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -64,6 +64,12 @@ public class ScheduleService {
         return scheduleRepository.findByGenerationAndStatusOrderByStartedAtAsc(generation, status);
     }
 
+    public List<Schedule> getTodayPublicAllSchedules(LocalDate date) {
+        return scheduleRepository.findAllByStartedAtBetweenAndStatusAndScheduleType(
+                date.atStartOfDay(), date.plusDays(1).atStartOfDay(),
+                ScheduleStatus.PUBLIC, ScheduleType.ALL);
+    }
+
     public Page<Schedule> getByGeneration(Generation generation, String searchWord, ScheduleType scheduleType, ScheduleStatus status, Pageable pageable) {
         return scheduleRepository
                 .retrieveByGenerationAndScheduleType(generation, searchWord, scheduleType, status, pageable);

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -65,7 +65,7 @@ public class ScheduleService {
     }
 
     public List<Schedule> getTodayPublicAllSchedules(LocalDate date) {
-        return scheduleRepository.findAllByStartedAtBetweenAndStatusAndScheduleType(
+        return scheduleRepository.findAllByStartedAtGreaterThanEqualAndStartedAtLessThanAndStatusAndScheduleType(
                 date.atStartOfDay(), date.plusDays(1).atStartOfDay(),
                 ScheduleStatus.PUBLIC, ScheduleType.ALL);
     }

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -59,6 +59,8 @@ public class AttendanceFacadeService {
 
     private static final String LEADER_NOTI_BEFORE_MINUTES_KEY = "leader-noti-before-minutes";
     private static final long DEFAULT_LEADER_NOTI_BEFORE_MINUTES = 3;
+    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
+    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
 
     private final AttendanceService attendanceService;
     private final MemberService memberService;
@@ -208,24 +210,21 @@ public class AttendanceFacadeService {
         if (LocalDateTime.now().getHour() != reminderHour) return;
 
         final List<Schedule> todaySchedules = scheduleService.getTodayPublicAllSchedules(LocalDate.now());
+        if (todaySchedules.isEmpty()) return;
+
+        final List<Member> leaders = resolveLeadersByPlatform().values().stream()
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+        if (leaders.isEmpty()) return;
 
         for (Schedule schedule : todaySchedules) {
             if (schedule.isOnline()) continue;
-
-            final List<Member> leaders = resolveLeadersByPlatform().values().stream()
-                    .flatMap(List::stream)
-                    .distinct()
-                    .collect(Collectors.toList());
-
-            if (leaders.isEmpty()) continue;
 
             pushNotiEventPublisher.publishPushNotiSendEvent(
                     new SeminarBadgeReminderVo(leaders, schedule.getName()));
         }
     }
-
-    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
-    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
 
     private int getSeminarReminderHour() {
         return storageService.findByKeyOptional(SEMINAR_REMINDER_HOUR_KEY)

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -20,6 +20,7 @@ import kr.mashup.branding.domain.pushnoti.vo.AttendanceLateForLeaderVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartedVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartingVo;
 import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
+import kr.mashup.branding.domain.pushnoti.vo.SeminarBadgeReminderVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
@@ -39,6 +40,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -194,6 +196,41 @@ public class AttendanceFacadeService {
                 now.plusMinutes(-PUSH_SCHEDULE_INTERVAL_MINUTES + afterMinutes),
                 now.plusMinutes(afterMinutes)
         );
+    }
+
+    /**
+     * 매시 정각: 당일 오프라인 공식 세미나가 있으면 리더에게 명찰 준비 알림
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional(readOnly = true)
+    public void sendSeminarBadgeReminderToLeaders() {
+        final int reminderHour = getSeminarReminderHour();
+        if (LocalDateTime.now().getHour() != reminderHour) return;
+
+        final List<Schedule> todaySchedules = scheduleService.getTodayPublicAllSchedules(LocalDate.now());
+
+        for (Schedule schedule : todaySchedules) {
+            if (schedule.isOnline()) continue;
+
+            final List<Member> leaders = resolveLeadersByPlatform().values().stream()
+                    .flatMap(List::stream)
+                    .distinct()
+                    .collect(Collectors.toList());
+
+            if (leaders.isEmpty()) continue;
+
+            pushNotiEventPublisher.publishPushNotiSendEvent(
+                    new SeminarBadgeReminderVo(leaders, schedule.getName()));
+        }
+    }
+
+    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
+    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
+
+    private int getSeminarReminderHour() {
+        return storageService.findByKeyOptional(SEMINAR_REMINDER_HOUR_KEY)
+                .map(storage -> ((Number) storage.getValueMap().get("value")).intValue())
+                .orElse(DEFAULT_SEMINAR_REMINDER_HOUR);
     }
 
     /**


### PR DESCRIPTION
## PR 타입
Feature

## 개요
공식 세미나(scheduleType=ALL)가 오프라인인 경우, 당일 특정 시간에 각 플랫폼 리더/서브리더에게 명찰 준비를 독려하는 FCM 푸시 알림 발송.

Closes #503

## 변경사항

### mashup-domain
- `ScheduleRepository`: 당일 PUBLIC + scheduleType=ALL 조회 쿼리 추가
- `ScheduleService`: `getTodayPublicAllSchedules(LocalDate)` 메서드 추가
- `SeminarBadgeReminderVo`: 명찰 준비 리마인드 푸시 VO 신규
- `Schedule.isOnline()`: 판별 로직을 `detailAddress == "ZOOM"` 기반으로 변경
  - 기존 로직(좌표 null 체크)은 오프라인 입력 실수 시 잘못 분류되는 문제
  - `ScheduleService.createLocation()`에서 이미 온라인일 때 `"ZOOM"`으로 저장하고 있어 이를 재활용

### mashup-member
- `AttendanceFacadeService`:
  - `sendSeminarBadgeReminderToLeaders()` 스케줄러 추가 (매시 정각)
  - 현재 시각이 Storage 설정 시간(`seminar-reminder-hour`, 기본 10시)과 일치할 때만 발동
  - 오프라인 공식 세미나만 대상 (`schedule.isOnline() == false`)
  - 리더/서브리더 FCM 대상 (`resolveLeadersByPlatform()` 재사용, 중복 제거)

## 푸시 메시지 예시
```
제목: 📌 세미나 준비 알림
본문: 오늘 {세미나명} 오프라인 세미나가 있어요. 명찰을 챙겨주세요!
```

## 설정

### 발송 시간 변경
```
POST /api/v1/storage
{
  "keyString": "seminar-reminder-hour",
  "valueMap": {"value": 9}
}
```
→ 즉시 오전 9시로 변경 (재배포 불필요)

- 미설정 시 기본 10시
- 재배포, DDL 불필요 (기존 Storage 활용)

## 관련 이슈
- Closes #503
- #510 온라인/오프라인 명시적 구분 필드 추가 (백로그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)