### PR TITLE
Merge dev to master - 출석 리더 알림 + Discord + 명찰 알림 + 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 /mashup-domain/src/main/generated/
+
+### Claude Code ###
+CLAUDE.local.md
+.serena/

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarBadgeReminderVo.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/pushnoti/vo/SeminarBadgeReminderVo.java
@@ -1,0 +1,19 @@
+package kr.mashup.branding.domain.pushnoti.vo;
+
+import java.util.List;
+import java.util.Map;
+
+import kr.mashup.branding.domain.member.Member;
+import kr.mashup.branding.domain.pushnoti.DataKeyType;
+import kr.mashup.branding.domain.pushnoti.LinkType;
+
+public class SeminarBadgeReminderVo extends PushNotiSendVo {
+    private static final PushType pushType = PushType.SEMINAR;
+    private static final String title = "📌 세미나 준비 알림";
+    private static final Map<String, String> dataMap = Map.of(DataKeyType.LINK.getKey(), LinkType.MAIN.toString());
+
+    public SeminarBadgeReminderVo(List<Member> leaders, String scheduleName) {
+        super(leaders, pushType, title,
+              "오늘 " + scheduleName + " 오프라인 세미나가 있어요. 명찰을 챙겨주세요!", dataMap);
+    }
+}

--- a/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/domain/schedule/Schedule.java
@@ -159,7 +159,7 @@ public class Schedule extends BaseEntity {
     }
 
     public Boolean isOnline() {
-        return this.location == null || this.location.getLatitude() == null || this.location.getLongitude() == null;
+        return this.location == null || "ZOOM".equals(this.location.getDetailAddress());
     }
 
     public Boolean checkAvailabilityByPlatform(Platform platform) {

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -17,6 +17,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
     Optional<Schedule> findByIdAndStatus(Long id, ScheduleStatus status);
 
     List<Schedule> findByGenerationAndStatusOrderByStartedAtAsc(Generation generation, ScheduleStatus status);
+
+    List<Schedule> findAllByStartedAtBetweenAndStatusAndScheduleType(
+            LocalDateTime from, LocalDateTime to, ScheduleStatus status, ScheduleType scheduleType);
 }
 /**
  * Schedule 연관관계

--- a/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/repository/schedule/ScheduleRepository.java
@@ -18,7 +18,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
 
     List<Schedule> findByGenerationAndStatusOrderByStartedAtAsc(Generation generation, ScheduleStatus status);
 
-    List<Schedule> findAllByStartedAtBetweenAndStatusAndScheduleType(
+    List<Schedule> findAllByStartedAtGreaterThanEqualAndStartedAtLessThanAndStatusAndScheduleType(
             LocalDateTime from, LocalDateTime to, ScheduleStatus status, ScheduleType scheduleType);
 }
 /**

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -64,6 +64,12 @@ public class ScheduleService {
         return scheduleRepository.findByGenerationAndStatusOrderByStartedAtAsc(generation, status);
     }
 
+    public List<Schedule> getTodayPublicAllSchedules(LocalDate date) {
+        return scheduleRepository.findAllByStartedAtBetweenAndStatusAndScheduleType(
+                date.atStartOfDay(), date.plusDays(1).atStartOfDay(),
+                ScheduleStatus.PUBLIC, ScheduleType.ALL);
+    }
+
     public Page<Schedule> getByGeneration(Generation generation, String searchWord, ScheduleType scheduleType, ScheduleStatus status, Pageable pageable) {
         return scheduleRepository
                 .retrieveByGenerationAndScheduleType(generation, searchWord, scheduleType, status, pageable);

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/schedule/ScheduleService.java
@@ -65,7 +65,7 @@ public class ScheduleService {
     }
 
     public List<Schedule> getTodayPublicAllSchedules(LocalDate date) {
-        return scheduleRepository.findAllByStartedAtBetweenAndStatusAndScheduleType(
+        return scheduleRepository.findAllByStartedAtGreaterThanEqualAndStartedAtLessThanAndStatusAndScheduleType(
                 date.atStartOfDay(), date.plusDays(1).atStartOfDay(),
                 ScheduleStatus.PUBLIC, ScheduleType.ALL);
     }

--- a/mashup-domain/src/main/java/kr/mashup/branding/service/storage/StorageService.java
+++ b/mashup-domain/src/main/java/kr/mashup/branding/service/storage/StorageService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -29,6 +30,11 @@ public class StorageService {
     @Transactional(readOnly = true)
     public Storage findByKey(String keyString) {
         return storageRepository.findByKeyString(keyString).orElseThrow(StorageNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Storage> findByKeyOptional(String keyString) {
+        return storageRepository.findByKeyString(keyString);
     }
 
     @Transactional(readOnly = true)

--- a/mashup-domain/src/test/java/kr/mashup/branding/service/storage/StorageServiceTest.java
+++ b/mashup-domain/src/test/java/kr/mashup/branding/service/storage/StorageServiceTest.java
@@ -1,0 +1,67 @@
+package kr.mashup.branding.service.storage;
+
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.domain.storage.StorageNotFoundException;
+import kr.mashup.branding.repository.storage.StorageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StorageServiceTest {
+
+    @Mock
+    private StorageRepository storageRepository;
+
+    @InjectMocks
+    private StorageService sut;
+
+    @Test
+    @DisplayName("findByKeyOptional은 키가 존재하면 Storage를 반환한다")
+    void findByKeyOptional_returnsStorage() {
+        // given
+        Storage storage = Storage.of("test-key", Map.of("value", 5));
+        when(storageRepository.findByKeyString("test-key")).thenReturn(Optional.of(storage));
+
+        // when
+        Optional<Storage> result = sut.findByKeyOptional("test-key");
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getValueMap().get("value")).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("findByKeyOptional은 키가 없으면 빈 Optional을 반환한다 (예외 없음)")
+    void findByKeyOptional_returnsEmptyWhenNotFound() {
+        // given
+        when(storageRepository.findByKeyString("missing-key")).thenReturn(Optional.empty());
+
+        // when
+        Optional<Storage> result = sut.findByKeyOptional("missing-key");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByKey는 키가 없으면 StorageNotFoundException을 던진다")
+    void findByKey_throwsWhenNotFound() {
+        // given
+        when(storageRepository.findByKeyString("missing-key")).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> sut.findByKey("missing-key"))
+                .isInstanceOf(StorageNotFoundException.class);
+    }
+}

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -59,6 +59,8 @@ public class AttendanceFacadeService {
 
     private static final String LEADER_NOTI_BEFORE_MINUTES_KEY = "leader-noti-before-minutes";
     private static final long DEFAULT_LEADER_NOTI_BEFORE_MINUTES = 3;
+    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
+    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
 
     private final AttendanceService attendanceService;
     private final MemberService memberService;
@@ -208,24 +210,21 @@ public class AttendanceFacadeService {
         if (LocalDateTime.now().getHour() != reminderHour) return;
 
         final List<Schedule> todaySchedules = scheduleService.getTodayPublicAllSchedules(LocalDate.now());
+        if (todaySchedules.isEmpty()) return;
+
+        final List<Member> leaders = resolveLeadersByPlatform().values().stream()
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
+        if (leaders.isEmpty()) return;
 
         for (Schedule schedule : todaySchedules) {
             if (schedule.isOnline()) continue;
-
-            final List<Member> leaders = resolveLeadersByPlatform().values().stream()
-                    .flatMap(List::stream)
-                    .distinct()
-                    .collect(Collectors.toList());
-
-            if (leaders.isEmpty()) continue;
 
             pushNotiEventPublisher.publishPushNotiSendEvent(
                     new SeminarBadgeReminderVo(leaders, schedule.getName()));
         }
     }
-
-    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
-    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
 
     private int getSeminarReminderHour() {
         return storageService.findByKeyOptional(SEMINAR_REMINDER_HOUR_KEY)

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -23,6 +23,7 @@ import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
+import kr.mashup.branding.domain.schedule.ScheduleType;
 import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
 import kr.mashup.branding.service.adminmember.AdminMemberService;
 import kr.mashup.branding.service.attendance.AttendanceCodeService;
@@ -226,6 +227,9 @@ public class AttendanceFacadeService {
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
+
+            if (schedule.getScheduleType() != ScheduleType.ALL) continue;
+
             final Generation generation = schedule.getGeneration();
 
             final List<Attendance> attendances = attendanceService.getByEvent(event);
@@ -291,6 +295,9 @@ public class AttendanceFacadeService {
         for (AttendanceCode attendanceCode : attendanceCodes) {
             final Event event = attendanceCode.getEvent();
             final Schedule schedule = event.getSchedule();
+
+            if (schedule.getScheduleType() != ScheduleType.ALL) continue;
+
             final Generation generation = schedule.getGeneration();
             scheduleName = schedule.getName();
             eventName = event.getEventName();

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -29,12 +29,12 @@ import kr.mashup.branding.service.attendance.AttendanceCodeService;
 import kr.mashup.branding.service.attendance.AttendanceService;
 import kr.mashup.branding.service.member.MemberService;
 import kr.mashup.branding.service.schedule.ScheduleService;
+import kr.mashup.branding.service.storage.StorageService;
 import kr.mashup.branding.ui.attendance.request.AttendanceCheckRequest;
 import kr.mashup.branding.ui.attendance.response.*;
 import kr.mashup.branding.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,8 +55,8 @@ public class AttendanceFacadeService {
     private final static long ATTENDANCE_END_AFTER_MINUTES = 3;
     private final static double ATTENDANCE_DISTANCE = 1000;
 
-    @Value("${attendance.leader-noti.before-minutes:3}")
-    private long leaderNotiBeforeMinutes;
+    private static final String LEADER_NOTI_BEFORE_MINUTES_KEY = "leader-noti-before-minutes";
+    private static final long DEFAULT_LEADER_NOTI_BEFORE_MINUTES = 3;
 
     private final AttendanceService attendanceService;
     private final MemberService memberService;
@@ -64,6 +64,7 @@ public class AttendanceFacadeService {
     private final AttendanceCodeService attendanceCodeService;
     private final PushNotiEventPublisher pushNotiEventPublisher;
     private final AdminMemberService adminMemberService;
+    private final StorageService storageService;
 
     /**
      * 출석 체크
@@ -201,7 +202,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceLatePushNotiToLeaders() {
-        sendLeaderPushNoti(findAllEndsWithin(leaderNotiBeforeMinutes), AttendanceLateForLeaderVo::new, "⏰ 출석 마감");
+        sendLeaderPushNoti(findAllEndsWithin(getLeaderNotiBeforeMinutes()), AttendanceLateForLeaderVo::new, "⏰ 출석 마감");
     }
 
     /**
@@ -210,7 +211,7 @@ public class AttendanceFacadeService {
     @Scheduled(cron = "0 * * * * *")
     @Transactional(readOnly = true)
     public void sendAttendanceAbsentPushNotiToLeaders() {
-        sendLeaderPushNoti(findAllLatenessEndsWithin(leaderNotiBeforeMinutes), AttendanceAbsentForLeaderVo::new, "⚠️ 지각 마감");
+        sendLeaderPushNoti(findAllLatenessEndsWithin(getLeaderNotiBeforeMinutes()), AttendanceAbsentForLeaderVo::new, "⚠️ 지각 마감");
     }
 
     /**
@@ -393,7 +394,7 @@ public class AttendanceFacadeService {
         }
         sb.append("** | ").append(notiLabel);
         if (deadlineAt != null) {
-            sb.append(" ").append(leaderNotiBeforeMinutes).append("분 전")
+            sb.append(" ").append(getLeaderNotiBeforeMinutes()).append("분 전")
                     .append(" (마감 ").append(String.format("%02d:%02d", deadlineAt.getHour(), deadlineAt.getMinute())).append(")");
         }
         sb.append("\n\n");
@@ -445,6 +446,15 @@ public class AttendanceFacadeService {
             return String.join(", ", nameList.subList(0, 20)) + " 외 " + (nameList.size() - 20) + "명";
         }
         return String.join(", ", nameList);
+    }
+
+    private long getLeaderNotiBeforeMinutes() {
+        try {
+            final Map<String, Object> valueMap = storageService.findByKey(LEADER_NOTI_BEFORE_MINUTES_KEY).getValueMap();
+            return ((Number) valueMap.get("value")).longValue();
+        } catch (Exception e) {
+            return DEFAULT_LEADER_NOTI_BEFORE_MINUTES;
+        }
     }
 
     private List<AttendanceCode> findAllLatenessEndsWithin(Long afterMinutes) {

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -20,6 +20,7 @@ import kr.mashup.branding.domain.pushnoti.vo.AttendanceLateForLeaderVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartedVo;
 import kr.mashup.branding.domain.pushnoti.vo.AttendanceStartingVo;
 import kr.mashup.branding.domain.pushnoti.vo.PushNotiSendVo;
+import kr.mashup.branding.domain.pushnoti.vo.SeminarBadgeReminderVo;
 import kr.mashup.branding.domain.schedule.Event;
 import kr.mashup.branding.domain.schedule.Schedule;
 import kr.mashup.branding.domain.schedule.ScheduleStatus;
@@ -39,6 +40,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -194,6 +196,41 @@ public class AttendanceFacadeService {
                 now.plusMinutes(-PUSH_SCHEDULE_INTERVAL_MINUTES + afterMinutes),
                 now.plusMinutes(afterMinutes)
         );
+    }
+
+    /**
+     * 매시 정각: 당일 오프라인 공식 세미나가 있으면 리더에게 명찰 준비 알림
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional(readOnly = true)
+    public void sendSeminarBadgeReminderToLeaders() {
+        final int reminderHour = getSeminarReminderHour();
+        if (LocalDateTime.now().getHour() != reminderHour) return;
+
+        final List<Schedule> todaySchedules = scheduleService.getTodayPublicAllSchedules(LocalDate.now());
+
+        for (Schedule schedule : todaySchedules) {
+            if (schedule.isOnline()) continue;
+
+            final List<Member> leaders = resolveLeadersByPlatform().values().stream()
+                    .flatMap(List::stream)
+                    .distinct()
+                    .collect(Collectors.toList());
+
+            if (leaders.isEmpty()) continue;
+
+            pushNotiEventPublisher.publishPushNotiSendEvent(
+                    new SeminarBadgeReminderVo(leaders, schedule.getName()));
+        }
+    }
+
+    private static final String SEMINAR_REMINDER_HOUR_KEY = "seminar-reminder-hour";
+    private static final int DEFAULT_SEMINAR_REMINDER_HOUR = 10;
+
+    private int getSeminarReminderHour() {
+        return storageService.findByKeyOptional(SEMINAR_REMINDER_HOUR_KEY)
+                .map(storage -> ((Number) storage.getValueMap().get("value")).intValue())
+                .orElse(DEFAULT_SEMINAR_REMINDER_HOUR);
     }
 
     /**

--- a/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
+++ b/mashup-member/src/main/java/kr/mashup/branding/facade/attendance/AttendanceFacadeService.java
@@ -449,12 +449,9 @@ public class AttendanceFacadeService {
     }
 
     private long getLeaderNotiBeforeMinutes() {
-        try {
-            final Map<String, Object> valueMap = storageService.findByKey(LEADER_NOTI_BEFORE_MINUTES_KEY).getValueMap();
-            return ((Number) valueMap.get("value")).longValue();
-        } catch (Exception e) {
-            return DEFAULT_LEADER_NOTI_BEFORE_MINUTES;
-        }
+        return storageService.findByKeyOptional(LEADER_NOTI_BEFORE_MINUTES_KEY)
+                .map(storage -> ((Number) storage.getValueMap().get("value")).longValue())
+                .orElse(DEFAULT_LEADER_NOTI_BEFORE_MINUTES);
     }
 
     private List<AttendanceCode> findAllLatenessEndsWithin(Long afterMinutes) {

--- a/mashup-member/src/main/resources/member-develop.yml
+++ b/mashup-member/src/main/resources/member-develop.yml
@@ -9,4 +9,4 @@ aws:
       expires-in: 120 # 2 minutes
 
 discord:
-  webhook-url: ENC(znLjYrU9jbwWYN5wtTFyxFPW2Zg8zO6ok4mJOr31ed65E6iIhrdqoubwEEkmPoRHy/4hDDXnK9J5vs+01DgBMga6mJtluvLDi5ler+5IQfWmfX2ywOgPTCSV0IYAR0uRG9nw9b5y+PDVP1/zN48XgOXkSU8KylC08SzATx+k86B8ae1RlzmB70uuwwvoXt59ECjpQBAXCPQk/ZtoXwX08w==)
+  webhook-url: ENC(e9xFFVS1pWf1D6oO5JhUJU73RdfwDyH2wMFELpZhRS0EvYAs3DAc1dyktnwZzZ+vodi1LPstejIyrOPYmHK05q2fulq3pBYKJEwubtdOLRpqchVQzKn/gtNMBAI8HD7ZTiJO0RQjlo7as+PuBctypaoenbUZtefAoI6e45Iv68RPTE/bhnzHKWKX271rkqLBYbxIy5EpO91Eme+/lSRPIA==)

--- a/mashup-member/src/test/java/kr/mashup/branding/facade/attendance/AttendanceFacadeServiceLeaderNotiTest.java
+++ b/mashup-member/src/test/java/kr/mashup/branding/facade/attendance/AttendanceFacadeServiceLeaderNotiTest.java
@@ -1,0 +1,97 @@
+package kr.mashup.branding.facade.attendance;
+
+import kr.mashup.branding.domain.attendance.AttendanceCode;
+import kr.mashup.branding.domain.storage.Storage;
+import kr.mashup.branding.infrastructure.pushnoti.PushNotiEventPublisher;
+import kr.mashup.branding.service.adminmember.AdminMemberService;
+import kr.mashup.branding.service.attendance.AttendanceCodeService;
+import kr.mashup.branding.service.attendance.AttendanceService;
+import kr.mashup.branding.service.member.MemberService;
+import kr.mashup.branding.service.schedule.ScheduleService;
+import kr.mashup.branding.service.storage.StorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceFacadeServiceLeaderNotiTest {
+
+    @Mock
+    private AttendanceService attendanceService;
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private ScheduleService scheduleService;
+    @Mock
+    private AttendanceCodeService attendanceCodeService;
+    @Mock
+    private PushNotiEventPublisher pushNotiEventPublisher;
+    @Mock
+    private AdminMemberService adminMemberService;
+    @Mock
+    private StorageService storageService;
+
+    @InjectMocks
+    private AttendanceFacadeService sut;
+
+    @Test
+    @DisplayName("Storage에 키가 없어도 스케줄러가 예외 없이 동작한다 (기본값 3분 사용)")
+    void sendAttendanceLatePushNoti_worksWithoutStorageKey() {
+        // given
+        when(storageService.findByKeyOptional("leader-noti-before-minutes"))
+                .thenReturn(Optional.empty());
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when - 예외 없이 정상 실행되어야 함
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(storageService).findByKeyOptional("leader-noti-before-minutes");
+        verify(attendanceCodeService).findAllByEndedAtLeftOpenBetween(any(), any());
+    }
+
+    @Test
+    @DisplayName("Storage에 키가 있으면 해당 값을 사용한다")
+    void sendAttendanceLatePushNoti_usesStorageValue() {
+        // given
+        Storage storage = Storage.of("leader-noti-before-minutes", Map.of("value", 5));
+        when(storageService.findByKeyOptional("leader-noti-before-minutes"))
+                .thenReturn(Optional.of(storage));
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(storageService).findByKeyOptional("leader-noti-before-minutes");
+    }
+
+    @Test
+    @DisplayName("AttendanceCode가 없으면 푸시를 발송하지 않는다")
+    void sendAttendanceLatePushNoti_noPushWhenNoAttendanceCode() {
+        // given
+        when(storageService.findByKeyOptional(any())).thenReturn(Optional.empty());
+        when(attendanceCodeService.findAllByEndedAtLeftOpenBetween(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        sut.sendAttendanceLatePushNotiToLeaders();
+
+        // then
+        verify(pushNotiEventPublisher, never()).publishPushNotiSendEvent(any());
+        verify(pushNotiEventPublisher, never()).publishDiscordEvent(any());
+    }
+}


### PR DESCRIPTION
## PR 타입
Release

## 개요
develop의 변경사항을 master로 머지. prod 배포 대상.

## 주요 변경사항

### 🆕 신규 기능
- **#490** 출석 마감/지각 마감 N분 전 플랫폼 리더에게 FCM 푸시 알림 (지각자/결석자 명단)
- **#491** Discord 웹훅으로 전체 플랫폼 출석 현황 알림 (마감 3분 전 + 최종 결과)
- **#499** Discord 메시지 개선 - 이모지, 통계, 일정명/이벤트명, 출석률, 전원출석 압축
- **#501** `leaderNotiBeforeMinutes`를 Storage 테이블로 이관 (Admin API로 실시간 변경 가능)
- **#506** dev Discord 웹훅을 전용 채널로 분리 (dev/prod 알림 혼동 해결)
- **#508** 리더 출석 알림을 공식 세미나(`scheduleType=ALL`)에만 동작하도록 제한
- **#509** 오프라인 공식 세미나 당일 10시(기본값) 리더에게 명찰 준비 푸시 알림

### 🐛 버그 수정
- **#497** 생일 푸시 알림 generation 필터 누락 버그 수정
- **#507** Storage 조회 시 트랜잭션 rollback 문제 수정

### 🔧 기타
- **#505** .gitignore에 CLAUDE.local.md, .serena/ 추가
- Storage / 리더 알림 단위 테스트 추가

## prod 사전 조건
- ✅ `admin_member.member_id` 컬럼 (이미 적용됨)
- ✅ 리더 AdminMember의 memberId 연결 (14명 모두 연결됨)
- ✅ Discord 웹훅 URL (prod yml에 ENC로 설정됨)
- 명찰 알림 시간 기본값 10시 → Storage 키 미설정 시 그대로 사용

## prod 배포 시 영향
- 출석 마감 3분 전 → 리더에게 FCM 푸시 + Discord 웹훅 발송
- 지각 마감 3분 전 → 동일
- 지각 마감 시점 → Discord에 최종 출석 결과
- 오프라인 공식 세미나 당일 10시 → 리더에게 명찰 준비 푸시
- 기존 멤버 출석 알림(Starting/Started/Ending)은 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)